### PR TITLE
단일 질문 보기 API

### DIFF
--- a/BE/src/questions/dto/read-question.dto.ts
+++ b/BE/src/questions/dto/read-question.dto.ts
@@ -1,0 +1,44 @@
+import {
+  IsBoolean,
+  IsDate,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+} from 'class-validator';
+
+export class ReadQuestionDto {
+  @IsNumber()
+  id: number;
+
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  nickname: string;
+
+  @IsNotEmpty()
+  @IsString()
+  tag: string;
+
+  @IsNotEmpty()
+  @IsDate()
+  createdAt: Date;
+
+  @IsNotEmpty()
+  @IsString()
+  programmingLanguage: string;
+
+  @IsBoolean()
+  isAdopted: boolean;
+
+  @IsNumber()
+  viewCount: number;
+
+  @IsNumber()
+  likeCount: number;
+
+  @IsBoolean()
+  isLiked: boolean;
+}

--- a/BE/src/questions/questions.controller.spec.ts
+++ b/BE/src/questions/questions.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestionsController } from './questions.controller';
+import { PrismaService } from '../prisma.service';
+import { QuestionsService } from './questions.service';
+
+describe('QuestionsController', () => {
+  let controller: QuestionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuestionsController],
+      providers: [QuestionsService, PrismaService],
+    }).compile();
+
+    controller = module.get<QuestionsController>(QuestionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, HttpStatus, Param, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { QuestionsService } from './questions.service';
+
+@Controller('questions')
+export class QuestionsController {
+  constructor(private readonly questionsService: QuestionsService) {}
+
+  @Get(':id')
+  async readOneQuestion(@Param('id') id: number, @Res() res: Response) {
+    try {
+      const question = await this.questionsService.readOneQuestion(id);
+
+      if (!question) {
+        return res
+          .status(HttpStatus.NOT_FOUND)
+          .json({ error: 'Question not found' });
+      }
+
+      return res.status(HttpStatus.OK).json(question);
+    } catch (error) {
+      return res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ error: 'Internal server error' });
+    }
+  }
+}

--- a/BE/src/questions/questions.module.ts
+++ b/BE/src/questions/questions.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { QuestionsController } from './questions.controller';
+import { QuestionsService } from './questions.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [QuestionsController],
+  providers: [QuestionsService, PrismaService],
+})
+export class QuestionsModule {}

--- a/BE/src/questions/questions.service.spec.ts
+++ b/BE/src/questions/questions.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestionsService } from './questions.service';
+import { PrismaService } from '../prisma.service';
+
+describe('QuestionsService', () => {
+  let service: QuestionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuestionsService, PrismaService],
+    }).compile();
+
+    service = module.get<QuestionsService>(QuestionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { ReadQuestionDto } from './dto/read-question.dto';
+
+@Injectable()
+export class QuestionsService {
+  constructor(private prisma: PrismaService) {}
+
+  async readOneQuestion(id: number): Promise<ReadQuestionDto> {
+    const question = await this.prisma.question.findUnique({
+      where: {
+        Id: id,
+      },
+      include: {
+        User: {
+          select: {
+            Nickname: true,
+            LikeInfo: {
+              where: {
+                LikedEntityId: id,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return {
+      id: question.Id,
+      title: question.Title,
+      nickname: question.User.Nickname,
+      tag: question.Tag,
+      createdAt: question.CreatedAt,
+      programmingLanguage: question.ProgrammingLanguage,
+      isAdopted: question.IsAdopted,
+      viewCount: question.ViewCount,
+      likeCount: question.LikeCount,
+      isLiked: question.User.LikeInfo[0]?.IsLiked || false,
+    };
+  }
+}


### PR DESCRIPTION
### 관련 이슈
#8 

### 구현한 기능
notion의 API 명세에 나와있는 대로 Response Body를 위한 DTO를 만들었습니다.

questions.service.ts 에서는 question id에 해당하는 question 데이터를 가져오면서, DTO에 필요한 추가적인 정보인 User Nickname과 LikeInfo도 함께 가져오도록 구현했습니다.

questions.controller.ts 에서는 questionService를 활용하여 question id에 해당하는 question 데이터를 가져오게 했습니다. 

이때 questionService를 활용하는 과정에서 에러가 발생하면 500에러를 반환하도록 하고 question id에 해당하는 question이 존재하지 않으면 404에러를 반환하도록 했습니다.

### 추가 논의 사항

ValidationPipe의 어떤 option들을 사용할 지 논의가 필요합니다.


⚠️ 확인할 사항 ⚠️
- [x] 제목에 PR 내용을 한문장으로 요약했나요?
- [x] pull request와 issue를 연동시켰나요?
- [x] 적절한 라벨을 달았나요?

