### PR TITLE
페이지네이션 컴포넌트 구현 및 질문 리스트 컴포넌트에 적용

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -30,18 +30,20 @@ const dummyQuestions = [
 function Main() {
   return (
     <main>
-      <div>
-        <UniqueQuestions questions={dummyQuestions} />
-        <QuestionList itemDatas={dummyQuestionList} />
+      <div className="inner">
+        <div>
+          <UniqueQuestions questions={dummyQuestions} />
+          <QuestionList itemDatas={dummyQuestionList} />
+        </div>
+        <aside>
+          <img
+            className="banner"
+            src="https://i.pinimg.com/originals/b0/df/95/b0df95cfc6f31293d002d4d6daac253c.jpg"
+            alt="포인트 정보가 들어갈 배너"
+          />
+          <QuestionProfile />
+        </aside>
       </div>
-      <aside>
-        <img
-          className="banner"
-          src="https://i.pinimg.com/originals/b0/df/95/b0df95cfc6f31293d002d4d6daac253c.jpg"
-          alt="포인트 정보가 들어갈 배너"
-        />
-        <QuestionProfile />
-      </aside>
     </main>
   );
 }

--- a/FE/src/components/MainHeader/MainHeader.styles.ts
+++ b/FE/src/components/MainHeader/MainHeader.styles.ts
@@ -60,12 +60,20 @@ export const Searchbar = styled.form`
 
 export const Container = styled.header`
   display: flex;
-  align-items: center;
-  gap: 1.5rem;
-
+  justify-content: center;
   width: 100%;
   height: 5rem;
   padding: 0 3rem;
-  border-bottom: 1px solid var(--color-grayscale-100);
   background-color: var(--color-grayscale-white);
+  border-bottom: 1px solid var(--color-grayscale-100);
+
+  .inner {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+
+    width: 100%;
+    height: 100%;
+    max-width: var(--max-width);
+  }
 `;

--- a/FE/src/components/MainHeader/MainHeader.tsx
+++ b/FE/src/components/MainHeader/MainHeader.tsx
@@ -27,8 +27,10 @@ function SearchBar() {
 export function MainHeader() {
   return (
     <S.Container>
-      <Logo />
-      <SearchBar />
+      <div className="inner">
+        <Logo />
+        <SearchBar />
+      </div>
     </S.Container>
   );
 }

--- a/FE/src/components/MainNav/MainNav.styles.ts
+++ b/FE/src/components/MainNav/MainNav.styles.ts
@@ -2,15 +2,21 @@ import styled from 'styled-components';
 
 export const MainNav = styled.nav`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-
+  justify-content: center;
   width: 100%;
   height: 3.2rem;
-  padding: 0 3rem;
-  border-bottom: 1px solid var(--color-grayscale-100);
   background-color: var(--color-grayscale-white);
+  border-bottom: 1px solid var(--color-grayscale-100);
+  padding: 0 3rem;
 
+  .inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    width: 100%;
+    max-width: var(--max-width);
+  }
   ol {
     display: flex;
     align-items: center;

--- a/FE/src/components/MainNav/MainNav.tsx
+++ b/FE/src/components/MainNav/MainNav.tsx
@@ -12,21 +12,23 @@ export function MainNav() {
 
   return (
     <S.MainNav>
-      <ol>
-        <li className={currentNavItem === 'question' ? 'selected' : ''}>
-          질문 게시판
-        </li>
-        <li className={currentNavItem === 'ranking' ? 'selected' : ''}>
-          랭킹 게시판
-        </li>
-        <li className={currentNavItem === 'point' ? 'selected' : ''}>
-          포인트 상점
-        </li>
-      </ol>
-      <button>
-        <img src={writeIcon} alt="질문하기" />
-        <span>질문하기</span>
-      </button>
+      <div className="inner">
+        <ol>
+          <li className={currentNavItem === 'question' ? 'selected' : ''}>
+            질문 게시판
+          </li>
+          <li className={currentNavItem === 'ranking' ? 'selected' : ''}>
+            랭킹 게시판
+          </li>
+          <li className={currentNavItem === 'point' ? 'selected' : ''}>
+            포인트 상점
+          </li>
+        </ol>
+        <button>
+          <img src={writeIcon} alt="질문하기" />
+          <span>질문하기</span>
+        </button>
+      </div>
     </S.MainNav>
   );
 }

--- a/FE/src/components/Pagination/Pagination.styles.ts
+++ b/FE/src/components/Pagination/Pagination.styles.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+export const Pagination = styled.div`
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  margin: 1rem 0;
+
+  > * {
+    cursor: pointer;
+  }
+
+  .page-list {
+    display: flex;
+    gap: 0.5rem;
+    font-weight: 300;
+
+    span {
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 50%;
+      text-align: center;
+      padding-top: 0.2rem;
+      transition: 0.1s ease-in all;
+    }
+    .current,
+    :hover {
+      color: var(--color-grayscale-white);
+      background-color: var(--color-blue-50);
+    }
+  }
+
+  button {
+    background: none;
+    border: none;
+  }
+`;

--- a/FE/src/components/Pagination/Pagination.tsx
+++ b/FE/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable no-unused-vars */
+import * as S from './Pagination.styles';
+import { useState } from 'react';
+
+interface PaginationProps {
+  wholePageCount: number;
+  currentPage: number;
+  handleCurrentPage: (nextPage: number) => void;
+  splitNumber: number;
+}
+
+const getCurrentNum = (
+  wholePageCount: number,
+  currentPage: number,
+  splitNumber: number,
+) => {
+  const idx = Math.floor(currentPage / splitNumber);
+  const result = Array.from({ length: wholePageCount }, (_, i) => i + 1).slice(
+    idx * splitNumber,
+    (idx + 1) * splitNumber,
+  );
+
+  return result;
+};
+
+export function Pagination({
+  wholePageCount,
+  currentPage,
+  handleCurrentPage,
+  splitNumber,
+}: PaginationProps) {
+  const [isFirstPage, setIsFirstPage] = useState<boolean>(currentPage === 0);
+  const [isLastPage, setIsLastPage] = useState<boolean>(
+    currentPage === wholePageCount,
+  );
+
+  const handleLeftButton = () => {
+    if (isFirstPage) {
+      return;
+    }
+
+    const nextPage = currentPage - 1;
+    handleCurrentPage(nextPage);
+
+    if (nextPage === 0) {
+      setIsFirstPage(true);
+    }
+    if (isLastPage) {
+      setIsLastPage(false);
+    }
+  };
+
+  const handleRightButton = () => {
+    if (isLastPage) {
+      return;
+    }
+
+    const nextPage = currentPage + 1;
+    handleCurrentPage(nextPage);
+
+    if (nextPage === wholePageCount - 1) {
+      setIsLastPage(true);
+    }
+    if (isFirstPage) {
+      setIsFirstPage(false);
+    }
+  };
+
+  const handlePageItem = (i: number) => {
+    setIsFirstPage(i === 0);
+    setIsLastPage(i === wholePageCount - 1);
+    handleCurrentPage(i);
+  };
+
+  return (
+    <S.Pagination>
+      <button
+        style={{ visibility: isFirstPage ? 'hidden' : 'visible' }}
+        onClick={handleLeftButton}
+      >
+        {'<'}
+      </button>
+      <ul className="page-list">
+        {getCurrentNum(wholePageCount, currentPage, splitNumber).map((i) => (
+          <span
+            className={i === currentPage + 1 ? 'current' : ''}
+            onClick={() => handlePageItem(i - 1)}
+          >
+            {i}
+          </span>
+        ))}
+      </ul>
+      <button
+        style={{ visibility: isLastPage ? 'hidden' : 'visible' }}
+        onClick={handleRightButton}
+      >
+        {'>'}
+      </button>
+    </S.Pagination>
+  );
+}

--- a/FE/src/components/QuestionList/QuestionList.styles.ts
+++ b/FE/src/components/QuestionList/QuestionList.styles.ts
@@ -49,6 +49,7 @@ export const Item = styled.li<ItemProps>`
       justify-content: left;
       gap: 0.2rem;
       width: 100%;
+      height: 1.3rem;
 
       h4 {
         flex-shrink: 1;

--- a/FE/src/components/QuestionList/QuestionList.tsx
+++ b/FE/src/components/QuestionList/QuestionList.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { Pagination } from '../index';
 import eyeIcon from '/icons/eye.svg';
 import likeIcon from '/icons/like.svg';
 import * as S from './QuestionList.styles';
@@ -25,6 +27,10 @@ const getColor = (programmingLanguage: string) => {
   }
 };
 
+const getCurrentItems = (itemDatas: ItemData[], currentPage: number) => {
+  return itemDatas.slice(currentPage * 10, currentPage * 10 + 10);
+};
+
 export function Header() {
   return (
     <S.Header>
@@ -33,6 +39,7 @@ export function Header() {
     </S.Header>
   );
 }
+
 export function Item({ itemData }: { itemData: ItemData }) {
   const {
     id,
@@ -75,14 +82,25 @@ export function Item({ itemData }: { itemData: ItemData }) {
 }
 
 export function QuestionList({ itemDatas }: { itemDatas: ItemData[] }) {
+  const [currentPage, setCurrentPage] = useState(0);
+  const wholePage = Math.ceil(itemDatas.length / 10);
+
   return (
     <S.QuestionList>
       <Header />
       <ul>
-        {itemDatas.map((itemData, idx) => (
+        {getCurrentItems(itemDatas, currentPage).map((itemData, idx) => (
           <Item key={idx} itemData={itemData} />
         ))}
       </ul>
+      <Pagination
+        wholePageCount={wholePage}
+        currentPage={currentPage}
+        handleCurrentPage={(i) => {
+          setCurrentPage(i);
+        }}
+        splitNumber={10}
+      />
     </S.QuestionList>
   );
 }

--- a/FE/src/components/index.ts
+++ b/FE/src/components/index.ts
@@ -6,6 +6,7 @@ import {
   QuestionList,
 } from './QuestionList/QuestionList';
 import { QuestionProfile } from './QuestionProfile/QuestionProfile';
+import { Pagination } from './Pagination/Pagination';
 
 export {
   MainHeader,
@@ -14,4 +15,5 @@ export {
   QuestionItem,
   QuestionList,
   QuestionProfile,
+  Pagination,
 };

--- a/FE/style/common.css
+++ b/FE/style/common.css
@@ -10,4 +10,5 @@
   --color-baekjoon: #0079c4;
   --color-leetcode: #fea116;
   --color-programmers: #1e2a3c;
+  --max-width: 1300px;
 }

--- a/FE/style/index.css
+++ b/FE/style/index.css
@@ -14,12 +14,20 @@ body {
 
 main {
   display: flex;
+  justify-content: center;
   gap: 2rem;
   width: 100%;
   padding: 2rem 3rem;
 }
 
-main > div {
+main > .inner {
+  display: flex;
+  gap: 2rem;
+  width: 100%;
+  max-width: var(--max-width);
+}
+
+main > .inner > div {
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -27,7 +35,7 @@ main > div {
   width: 1px;
 }
 
-main > aside {
+main > .inner > aside {
   display: flex;
   flex-direction: column;
   gap: 2rem;


### PR DESCRIPTION
## 관련 이슈

Close #7 

<br/>

## 구현한 기능

![pagination](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/afa01dbf-7f13-4cc0-9da3-da974307eeae)

<br/>

### ⚒️ feat: 페이지네이션 컴포넌트 구현

페이지네이션 컴포넌트를 구현했습니다.
공통 컴포넌트인 만큼 최대한 의존성을 줄이고 유연성을 늘리고자 했습니다.
- 페이지네이션의 prop을 통해 한번에 보여줄 페이지의 개수를 유연하게 조절할 수 있습니다.
- 가장 첫번째 페이지, 혹은 가장 마지막 페이지에 도달하면 해당 방향의 버튼이 비활성화 됩니다.

<br/>

### ⚒️ feat: 질문 리스트 컴포넌트에 페이지네이션 컴포넌트 적용

질문 리스트의 컴포넌트에 페이지네이션 컴포넌트를 적용했습니다.
현재 10페이지 단위로 페이지네이션이 이루어지도록 했습니다.

<br/>

### ⚒️ feat: 페이지 넓이 제한

CSS를 통해 페이지 넓이를 제한했습니다.
이제 화면을 축소해도 과도한 화면 늘어짐이 발생하지 않습니다.

<br/>

## 추가 논의 사항

질문 리스트의 한 페이지당 아이템 개수에 대한 논의가 있어야 할 것 같습니다.
보통 20 - 50개 정도 보여주더라고요.

<br/>
<br/>