### PR TITLE
질문 리스트 API

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AnswersModule } from './answers/answers.module';
+import { QuestionsModule } from './questions/questions.module';
 
 @Module({
-  imports: [AnswersModule],
+  imports: [AnswersModule, QuestionsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -4,7 +4,7 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   await app.listen(3000);
 }
 bootstrap();

--- a/BE/src/questions/dto/read-question-list.dto.ts
+++ b/BE/src/questions/dto/read-question-list.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsBoolean,
+  IsDate,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+} from 'class-validator';
+
+export class ReadQuestionListDto {
+  @IsNumber()
+  id: number;
+
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  nickname: string;
+
+  @IsNotEmpty()
+  @IsString()
+  tag: string;
+
+  @IsDate()
+  createdAt: Date;
+
+  @IsNotEmpty()
+  @IsString()
+  programmingLanguage: string;
+
+  @IsBoolean()
+  isAdopted: boolean;
+
+  @IsNumber()
+  viewCount: number;
+
+  @IsNumber()
+  likeCount: number;
+}

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, HttpStatus, Param, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
+import { ReadQuestionListDto } from './dto/read-question-list.dto';
 
 @Controller('questions')
 export class QuestionsController {
@@ -18,6 +19,25 @@ export class QuestionsController {
       }
 
       return res.status(HttpStatus.OK).json(question);
+    } catch (error) {
+      return res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ error: 'Internal server error' });
+    }
+  }
+
+  @Get('lists/:page')
+  async getQuestionList(@Param('page') page: number, @Res() res: Response) {
+    try {
+      const questionList: ReadQuestionListDto[] =
+        await this.questionsService.readQuestionList(page);
+      if (questionList.length === 0) {
+        return res
+          .status(HttpStatus.NOT_FOUND)
+          .json({ error: 'No questions found' });
+      }
+
+      return res.status(HttpStatus.OK).json(questionList);
     } catch (error) {
       return res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { ReadQuestionDto } from './dto/read-question.dto';
+import { ReadQuestionListDto } from './dto/read-question-list.dto';
 
 @Injectable()
 export class QuestionsService {
@@ -37,5 +38,34 @@ export class QuestionsService {
       likeCount: question.LikeCount,
       isLiked: question.User.LikeInfo[0]?.IsLiked || false,
     };
+  }
+
+  async readQuestionList(page: number): Promise<ReadQuestionListDto[]> {
+    const pageSize = 10; // 한 페이지당 질문 개수는 10개
+    const skip = (page - 1) * pageSize;
+
+    const questions = await this.prisma.question.findMany({
+      skip,
+      take: pageSize,
+      include: {
+        User: {
+          select: {
+            Nickname: true,
+          },
+        },
+      },
+    });
+
+    return questions.map((question) => ({
+      id: question.Id,
+      title: question.Title,
+      nickname: question.User.Nickname,
+      tag: question.Tag,
+      createdAt: question.CreatedAt,
+      programmingLanguage: question.ProgrammingLanguage,
+      isAdopted: question.IsAdopted,
+      viewCount: question.ViewCount,
+      likeCount: question.LikeCount,
+    }));
   }
 }


### PR DESCRIPTION
### 관련 이슈
#19 

### 구현한 기능

<!--
  구현한 기능에 대해 적어주세요.
  기능을 어떤 방식으로 구현했는지에 대해 자세히 적어주세요.
  필요하다면 구현한 기능과 관련된 이미지 및 gif도 함께 첨부해주세요.
-->

notion의 API 명세에 나와있는 대로 Response Body를 위한 DTO를 만들었습니다.

questions.service.ts 에서는 page에 해당하는 구간의 question을 가져오면서 User의 Nickname도 가져오도록 했습니다. 이후 question을 ReadQuestionListDto에 맞게 map 해주었습니다.

questions.controller.ts 에서는 questionService를 활용하여 page에 해당하는 question 데이터들을 가져오게 했습니다.

이때 questionService를 활용하는 과정에서 에러가 발생하면 500에러를 반환하도록 하고 질문리스트가 존재하지 않으면 404에러를 반환하도록 했습니다.



⚠️ 확인할 사항 ⚠️
- [x] 제목에 PR 내용을 한문장으로 요약했나요?
- [x] pull request와 issue를 연동시켰나요?
- [x] 적절한 라벨을 달았나요?

-->