### PR TITLE
단일 질문 생성 API

### DIFF
--- a/BE/src/questions/dto/create-question.dto.ts
+++ b/BE/src/questions/dto/create-question.dto.ts
@@ -1,0 +1,24 @@
+// { title, content, tag, programmingLanguage, originalLink }
+import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+
+export class CreateQuestionDto {
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+
+  @IsNotEmpty()
+  @IsString()
+  tag: string;
+
+  @IsNotEmpty()
+  @IsString()
+  programmingLanguage: string;
+
+  @IsNotEmpty()
+  @IsUrl()
+  originalLink: string;
+}

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -27,10 +27,17 @@ export class QuestionsController {
         createQuestionDto,
         1,
       );
+
       return res
         .status(HttpStatus.CREATED)
         .json({ message: 'Question created successfully', id: questionId });
     } catch (error) {
+      if (error.message === 'Failed to create question') {
+        return res
+          .status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .json({ error: 'Internal server error' });
+      }
+
       return res.status(HttpStatus.BAD_REQUEST).json({ error: 'Bad request' });
     }
   }

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -7,8 +7,6 @@ import {
   Param,
   Post,
   Res,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
@@ -20,7 +18,6 @@ export class QuestionsController {
 
   // TODO: Use UserGuard to obtain the user ID and associate it with the question
   @Post()
-  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   async createQuestion(
     @Body() createQuestionDto: CreateQuestionDto,
     @Res() res: Response,

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -1,10 +1,42 @@
-import { Controller, Get, HttpStatus, Param, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Res,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
+import { CreateQuestionDto } from './dto/create-question.dto';
 
 @Controller('questions')
 export class QuestionsController {
   constructor(private readonly questionsService: QuestionsService) {}
+
+  // TODO: Use UserGuard to obtain the user ID and associate it with the question
+  @Post()
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  async createQuestion(
+    @Body() createQuestionDto: CreateQuestionDto,
+    @Res() res: Response,
+  ) {
+    try {
+      const questionId = await this.questionsService.createOneQuestion(
+        createQuestionDto,
+        1,
+      );
+      return res
+        .status(HttpStatus.CREATED)
+        .json({ message: 'Question created successfully', id: questionId });
+    } catch (error) {
+      return res.status(HttpStatus.BAD_REQUEST).json({ error: 'Bad request' });
+    }
+  }
 
   @Get(':id')
   async readOneQuestion(@Param('id') id: number, @Res() res: Response) {

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -7,7 +7,6 @@ import { CreateQuestionDto } from './dto/create-question.dto';
 export class QuestionsService {
   constructor(private prisma: PrismaService) {}
 
-  // TODO: Implement logic to associate the question with the user by including the user id
   async createOneQuestion(
     createQuestionDto: CreateQuestionDto,
     userId: number,

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -1,10 +1,33 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { ReadQuestionDto } from './dto/read-question.dto';
+import { CreateQuestionDto } from './dto/create-question.dto';
 
 @Injectable()
 export class QuestionsService {
   constructor(private prisma: PrismaService) {}
+
+  // TODO: Implement logic to associate the question with the user by including the user id
+  async createOneQuestion(
+    createQuestionDto: CreateQuestionDto,
+    userId: number,
+  ): Promise<number> {
+    const question = await this.prisma.question.create({
+      data: {
+        User: {
+          connect: {
+            Id: userId,
+          },
+        },
+        Title: createQuestionDto.title,
+        Content: createQuestionDto.content,
+        Tag: createQuestionDto.tag,
+        ProgrammingLanguage: createQuestionDto.programmingLanguage,
+        OriginalLink: createQuestionDto.originalLink,
+      },
+    });
+    return question.Id;
+  }
 
   async readOneQuestion(id: number): Promise<ReadQuestionDto> {
     const question = await this.prisma.question.findUnique({

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -12,21 +12,25 @@ export class QuestionsService {
     createQuestionDto: CreateQuestionDto,
     userId: number,
   ): Promise<number> {
-    const question = await this.prisma.question.create({
-      data: {
-        User: {
-          connect: {
-            Id: userId,
+    try {
+      const question = await this.prisma.question.create({
+        data: {
+          User: {
+            connect: {
+              Id: userId,
+            },
           },
+          Title: createQuestionDto.title,
+          Content: createQuestionDto.content,
+          Tag: createQuestionDto.tag,
+          ProgrammingLanguage: createQuestionDto.programmingLanguage,
+          OriginalLink: createQuestionDto.originalLink,
         },
-        Title: createQuestionDto.title,
-        Content: createQuestionDto.content,
-        Tag: createQuestionDto.tag,
-        ProgrammingLanguage: createQuestionDto.programmingLanguage,
-        OriginalLink: createQuestionDto.originalLink,
-      },
-    });
-    return question.Id;
+      });
+      return question.Id;
+    } catch (error) {
+      throw new Error('Failed to create question');
+    }
   }
 
   async readOneQuestion(id: number): Promise<ReadQuestionDto> {


### PR DESCRIPTION
### 관련 이슈
#52 

### 구현한 기능

notion의 API 명세에 나와있는 대로 Request Body를 위한 DTO를 만들었습니다.

questions.service.ts 에서는 DTO와 UserId를 이용하여 question을 생성하게 했습니다.

questions.controller.ts 에서는 questionService를 활용하여 DTO와 UserId를 토대로 question 생성을 요청하도록 했습니다.

이때 DTO의 값이 검증에 실패하는 경우에는 BAD_REQUEST를 반환하고 question 생성에 실패한 경우에는INTERNAL_SERVER_ERROR를 반환하고 성공한 경우에는 CREATED를 반환하도록 했습니다.


<!--

⚠️ 확인할 사항 ⚠️
- [x] 제목에 PR 내용을 한문장으로 요약했나요?
- [x] pull request와 issue를 연동시켰나요?
- [x] 적절한 라벨을 달았나요?

-->