### PR TITLE
단일 질문 삭제 API

### DIFF
--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -74,19 +74,14 @@ export class QuestionsController {
           .json({ message: 'Question deleted successfully' });
       } else {
         return res
-          .status(HttpStatus.NOT_FOUND)
-          .json({ error: 'Question not found or already adopted' });
+          .status(HttpStatus.FORBIDDEN)
+          .json({ error: 'Question is not able to deleted' });
       }
     } catch (error) {
-      if (error.message === 'User is not the owner of the question') {
-        return res
-          .status(HttpStatus.FORBIDDEN)
-          .json({ error: 'User is not the owner of the question' });
-      }
+      return res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ error: 'Internal server error' });
     }
-    return res
-      .status(HttpStatus.INTERNAL_SERVER_ERROR)
-      .json({ error: 'Internal server error' });
   }
 
   @Get('lists/:page')

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -1,10 +1,46 @@
-import { Controller, Get, HttpStatus, Param, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Res,
+} from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
+import { CreateQuestionDto } from './dto/create-question.dto';
 
 @Controller('questions')
 export class QuestionsController {
   constructor(private readonly questionsService: QuestionsService) {}
+
+  // TODO: Use UserGuard to obtain the user ID and associate it with the question
+  @Post()
+  async createQuestion(
+    @Body() createQuestionDto: CreateQuestionDto,
+    @Res() res: Response,
+  ) {
+    try {
+      const questionId = await this.questionsService.createOneQuestion(
+        createQuestionDto,
+        1,
+      );
+
+      return res
+        .status(HttpStatus.CREATED)
+        .json({ message: 'Question created successfully', id: questionId });
+    } catch (error) {
+      if (error.message === 'Failed to create question') {
+        return res
+          .status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .json({ error: 'Internal server error' });
+      }
+
+      return res.status(HttpStatus.BAD_REQUEST).json({ error: 'Bad request' });
+    }
+  }
 
   @Get(':id')
   async readOneQuestion(@Param('id') id: number, @Res() res: Response) {
@@ -23,5 +59,32 @@ export class QuestionsController {
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .json({ error: 'Internal server error' });
     }
+  }
+
+  // TODO: use UserGuard to check if user is the owner of the question
+  @Delete(':id')
+  async deleteOneQuestion(@Param('id') id: number, @Res() res: Response) {
+    try {
+      const isDeleted = await this.questionsService.deleteOneQuestion(id, 1);
+
+      if (isDeleted) {
+        return res
+          .status(HttpStatus.OK)
+          .json({ message: 'Question deleted successfully' });
+      } else {
+        return res
+          .status(HttpStatus.NOT_FOUND)
+          .json({ error: 'Question not found or already adopted' });
+      }
+    } catch (error) {
+      if (error.message === 'User is not the owner of the question') {
+        return res
+          .status(HttpStatus.FORBIDDEN)
+          .json({ error: 'User is not the owner of the question' });
+      }
+    }
+    return res
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal server error' });
   }
 }

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -87,6 +87,7 @@ export class QuestionsController {
     return res
       .status(HttpStatus.INTERNAL_SERVER_ERROR)
       .json({ error: 'Internal server error' });
+  }
 
   @Get('lists/:page')
   async getQuestionList(@Param('page') page: number, @Res() res: Response) {

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -88,6 +88,7 @@ export class QuestionsService {
     if (question.User.Id !== userId) {
       throw new Error('User is not the owner of the question');
     }
+  }
 
     await this.prisma.question.delete({
       where: {

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -1,10 +1,37 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { ReadQuestionDto } from './dto/read-question.dto';
+import { CreateQuestionDto } from './dto/create-question.dto';
 
 @Injectable()
 export class QuestionsService {
   constructor(private prisma: PrismaService) {}
+
+  // TODO: Implement logic to associate the question with the user by including the user id
+  async createOneQuestion(
+    createQuestionDto: CreateQuestionDto,
+    userId: number,
+  ): Promise<number> {
+    try {
+      const question = await this.prisma.question.create({
+        data: {
+          User: {
+            connect: {
+              Id: userId,
+            },
+          },
+          Title: createQuestionDto.title,
+          Content: createQuestionDto.content,
+          Tag: createQuestionDto.tag,
+          ProgrammingLanguage: createQuestionDto.programmingLanguage,
+          OriginalLink: createQuestionDto.originalLink,
+        },
+      });
+      return question.Id;
+    } catch (error) {
+      throw new Error('Failed to create question');
+    }
+  }
 
   async readOneQuestion(id: number): Promise<ReadQuestionDto> {
     const question = await this.prisma.question.findUnique({
@@ -37,5 +64,38 @@ export class QuestionsService {
       likeCount: question.LikeCount,
       isLiked: question.User.LikeInfo[0]?.IsLiked || false,
     };
+  }
+
+  // TODO: check if user is owner of the question
+  async deleteOneQuestion(id: number, userId: number): Promise<boolean> {
+    const question = await this.prisma.question.findUnique({
+      where: {
+        Id: id,
+        IsAdopted: false,
+      },
+      include: {
+        User: {
+          select: {
+            Id: true,
+          },
+        },
+      },
+    });
+
+    if (!question) {
+      return false;
+    }
+
+    if (question.User.Id !== userId) {
+      throw new Error('User is not the owner of the question');
+    }
+
+    await this.prisma.question.delete({
+      where: {
+        Id: id,
+      },
+    });
+
+    return true;
   }
 }

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -1,37 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { ReadQuestionDto } from './dto/read-question.dto';
-import { CreateQuestionDto } from './dto/create-question.dto';
 
 @Injectable()
 export class QuestionsService {
   constructor(private prisma: PrismaService) {}
-
-  // TODO: Implement logic to associate the question with the user by including the user id
-  async createOneQuestion(
-    createQuestionDto: CreateQuestionDto,
-    userId: number,
-  ): Promise<number> {
-    try {
-      const question = await this.prisma.question.create({
-        data: {
-          User: {
-            connect: {
-              Id: userId,
-            },
-          },
-          Title: createQuestionDto.title,
-          Content: createQuestionDto.content,
-          Tag: createQuestionDto.tag,
-          ProgrammingLanguage: createQuestionDto.programmingLanguage,
-          OriginalLink: createQuestionDto.originalLink,
-        },
-      });
-      return question.Id;
-    } catch (error) {
-      throw new Error('Failed to create question');
-    }
-  }
 
   async readOneQuestion(id: number): Promise<ReadQuestionDto> {
     const question = await this.prisma.question.findUnique({
@@ -66,7 +39,6 @@ export class QuestionsService {
     };
   }
 
-  // TODO: check if user is owner of the question
   async deleteOneQuestion(id: number, userId: number): Promise<boolean> {
     const question = await this.prisma.question.findUnique({
       where: {

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -67,36 +67,24 @@ export class QuestionsService {
   }
 
   async deleteOneQuestion(id: number, userId: number): Promise<boolean> {
-    const question = await this.prisma.question.findUnique({
-      where: {
-        Id: id,
-        IsAdopted: false,
-      },
-      include: {
-        User: {
-          select: {
-            Id: true,
-          },
+    try {
+      await this.prisma.question.update({
+        where: {
+          Id: id,
+          UserId: userId,
+          IsAdopted: false,
+          DeletedAt: null,
         },
-      },
-    });
-
-    if (!question) {
+        data: {
+          DeletedAt: new Date(),
+        },
+      });
+      return true;
+    } catch (error) {
       return false;
-    }
-
-    if (question.User.Id !== userId) {
-      throw new Error('User is not the owner of the question');
     }
   }
 
-    await this.prisma.question.delete({
-      where: {
-        Id: id,
-      },
-    });
-
-    return true;
   async readQuestionList(page: number): Promise<ReadQuestionListDto[]> {
     const pageSize = 10; // 한 페이지당 질문 개수는 10개
     const skip = (page - 1) * pageSize;


### PR DESCRIPTION
### 관련 이슈
#54 

### 구현한 기능

questions.controller.ts 에서는 questionService를 활용하여 QuestionId와 UserId를 토대로 question 삭제를 요청하도록 했습니다.

이때 QuestionId에 해당하는 question이 존재하지 않거나 이미 채택된 경우에는 NOT_FOUND를 반환하고 위의 경우가 아닌데 question을 작성한 User가 삭제 요청한 것이 아니라면  FORBIDDEN을 반환하고 삭제가 성공하는 경우에는 OK를 반환하고 그 외의 경우 INTERNAL_SERVER_ERROR를 반환하도록 했습니다.

<!--

⚠️ 확인할 사항 ⚠️
- [x] 제목에 PR 내용을 한문장으로 요약했나요?
- [x] pull request와 issue를 연동시켰나요?
- [x] 적절한 라벨을 달았나요?

-->