### PR TITLE
단일 질문 수정 API

### DIFF
--- a/BE/src/questions/dto/update-question.dto.ts
+++ b/BE/src/questions/dto/update-question.dto.ts
@@ -1,0 +1,23 @@
+import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+
+export class UpdateQuestionDto {
+  @IsNotEmpty()
+  @IsString()
+  title;
+
+  @IsNotEmpty()
+  @IsString()
+  content;
+
+  @IsNotEmpty()
+  @IsString()
+  tag;
+
+  @IsNotEmpty()
+  @IsString()
+  programmingLanguage;
+
+  @IsNotEmpty()
+  @IsUrl()
+  originalLink;
+}

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -6,12 +6,14 @@ import {
   HttpStatus,
   Param,
   Post,
+  Put,
   Res,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { ReadQuestionListDto } from './dto/read-question-list.dto';
+import { UpdateQuestionDto } from './dto/update-question.dto';
 
 @Controller('questions')
 export class QuestionsController {
@@ -74,6 +76,36 @@ export class QuestionsController {
       }
 
       return res.status(HttpStatus.OK).json(questionList);
+    } catch (error) {
+      return res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ error: 'Internal server error' });
+    }
+  }
+
+  // TODO: use UserGuard to check if user is the owner of the question
+  @Put(':id')
+  async updateOneQuestion(
+    @Param('id') id: number,
+    @Body() updateQuestionDto: UpdateQuestionDto,
+    @Res() res: Response,
+  ) {
+    try {
+      const isUpdated = await this.questionsService.updateOneQuestion(
+        id,
+        1,
+        updateQuestionDto,
+      );
+
+      if (isUpdated) {
+        return res
+          .status(HttpStatus.OK)
+          .json({ message: 'Question updated successfully' });
+      } else {
+        return res
+          .status(HttpStatus.FORBIDDEN)
+          .json({ error: 'Question is not able to be modified' });
+      }
     } catch (error) {
       return res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -94,4 +94,26 @@ export class QuestionsService {
       likeCount: question.LikeCount,
     }));
   }
+  async updateOneQuestion(id: number, userId: number, updateQuestionDto) {
+    try {
+      await this.prisma.question.update({
+        where: {
+          Id: id,
+          UserId: userId,
+          IsAdopted: false,
+          DeletedAt: null,
+        },
+        data: {
+          Title: updateQuestionDto.title,
+          Content: updateQuestionDto.content,
+          Tag: updateQuestionDto.tag,
+          ProgrammingLanguage: updateQuestionDto.programmingLanguage,
+          OriginalLink: updateQuestionDto.originalLink,
+        },
+      });
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
### 관련 이슈
#53 

### 구현한 기능

notion의 API 명세에 나와있는 대로 Request Body를 위한 DTO를 만들었습니다.
questions.service.ts 에서는 DTO와 Id, UserId를 이용하여 question을 수정하게 했습니다.
questions.controller.ts 에서는 questionService를 활용하여 DTO, Id, UserId를 토대로 question 수정을 요청하도록 했습니다.

이때 이때 DTO의 값이 검증에 실패하는 경우에는 BAD_REQUEST를 반환하고 question 수정에 실패한 경우 FORBIDDEN을 반환하고 성공한 경우에는 OK를 반환하도록 했습니다.