### PR TITLE
질문 리스트, 필터, 정렬 API 통합

### DIFF
--- a/BE/src/questions/dto/read-question-list-options.dto.ts
+++ b/BE/src/questions/dto/read-question-list-options.dto.ts
@@ -1,0 +1,36 @@
+import { IsString, IsIn, Min, IsOptional, IsNumber } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+
+export class QuestionListOptionsDto {
+  @IsOptional()
+  @IsString()
+  tag?: string;
+
+  @IsOptional()
+  @IsString()
+  programmingLanguage?: string;
+
+  @IsOptional()
+  @Transform(({ value }) =>
+    value === '1' ? true : value === '0' ? false : undefined,
+  )
+  isAdopted?: boolean;
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortByCreatedAt?: 'asc' | 'desc' = 'desc';
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortByViewCount?: 'asc' | 'desc';
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortByLikeCount?: 'asc' | 'desc';
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+}

--- a/BE/src/questions/questions.controller.spec.ts
+++ b/BE/src/questions/questions.controller.spec.ts
@@ -2,9 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { QuestionsController } from './questions.controller';
 import { PrismaService } from '../prisma.service';
 import { QuestionsService } from './questions.service';
+import { ReadQuestionListDto } from './dto/read-question-list.dto';
 
 describe('QuestionsController', () => {
   let controller: QuestionsController;
+  let service: QuestionsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -13,9 +15,82 @@ describe('QuestionsController', () => {
     }).compile();
 
     controller = module.get<QuestionsController>(QuestionsController);
+    service = module.get<QuestionsService>(QuestionsService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getQuestionList', () => {
+    it('should return a list of questions', async () => {
+      const mockQuestionList: ReadQuestionListDto[] = [
+        {
+          id: 1,
+          title: 'Question 1',
+          nickname: 'name 1',
+          tag: 'nestjs',
+          isAdopted: false,
+          likeCount: 0,
+          viewCount: 0,
+          createdAt: new Date(),
+          programmingLanguage: 'JavaScript',
+        },
+        {
+          id: 2,
+          title: 'Question 2',
+          nickname: 'name 2',
+          tag: 'nestjs',
+          isAdopted: false,
+          likeCount: 0,
+          viewCount: 0,
+          createdAt: new Date(),
+          programmingLanguage: 'JavaScript',
+        },
+      ];
+
+      jest
+        .spyOn(service, 'readQuestionList')
+        .mockResolvedValue(mockQuestionList);
+
+      const response = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getQuestionList(
+        {
+          page: 1,
+          isAdopted: false,
+          programmingLanguage: 'JavaScript',
+          tag: 'nestjs',
+          sortByLikeCount: 'asc',
+          sortByViewCount: 'desc',
+          sortByCreatedAt: 'desc',
+        },
+        response as any, // Type casting for simplicity
+      );
+
+      expect(response.status).toHaveBeenCalledWith(200);
+      expect(response.json).toHaveBeenCalledWith(mockQuestionList);
+    });
+
+    it('should handle internal server error', async () => {
+      jest
+        .spyOn(service, 'readQuestionList')
+        .mockRejectedValue(new Error('Internal server error'));
+
+      const response = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getQuestionList({}, response as any);
+
+      expect(response.status).toHaveBeenCalledWith(500);
+      expect(response.json).toHaveBeenCalledWith({
+        error: 'Internal server error',
+      });
+    });
   });
 });

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -6,16 +6,34 @@ import {
   HttpStatus,
   Param,
   Post,
+  Query,
   Res,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { ReadQuestionListDto } from './dto/read-question-list.dto';
+import { QuestionListOptionsDto } from './dto/read-question-list-options.dto';
 
 @Controller('questions')
 export class QuestionsController {
   constructor(private readonly questionsService: QuestionsService) {}
+
+  @Get('lists')
+  async getQuestionList(
+    @Query() options: QuestionListOptionsDto,
+    @Res() res: Response,
+  ) {
+    try {
+      const questionList: ReadQuestionListDto[] =
+        await this.questionsService.readQuestionList(options);
+      return res.status(HttpStatus.OK).json(questionList);
+    } catch (error) {
+      return res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ error: 'Internal server error' });
+    }
+  }
 
   // TODO: Use UserGuard to obtain the user ID and associate it with the question
   @Post()
@@ -77,25 +95,6 @@ export class QuestionsController {
           .status(HttpStatus.FORBIDDEN)
           .json({ error: 'Question is not able to deleted' });
       }
-    } catch (error) {
-      return res
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .json({ error: 'Internal server error' });
-    }
-  }
-
-  @Get('lists/:page')
-  async getQuestionList(@Param('page') page: number, @Res() res: Response) {
-    try {
-      const questionList: ReadQuestionListDto[] =
-        await this.questionsService.readQuestionList(page);
-      if (questionList.length === 0) {
-        return res
-          .status(HttpStatus.NOT_FOUND)
-          .json({ error: 'No questions found' });
-      }
-
-      return res.status(HttpStatus.OK).json(questionList);
     } catch (error) {
       return res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -105,25 +105,6 @@ export class QuestionsController {
     }
   }
 
-  @Get('lists/:page')
-  async getQuestionList(@Param('page') page: number, @Res() res: Response) {
-    try {
-      const questionList: ReadQuestionListDto[] =
-        await this.questionsService.readQuestionList(page);
-      if (questionList.length === 0) {
-        return res
-          .status(HttpStatus.NOT_FOUND)
-          .json({ error: 'No questions found' });
-      }
-
-      return res.status(HttpStatus.OK).json(questionList);
-    } catch (error) {
-      return res
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .json({ error: 'Internal server error' });
-    }
-  }
-
   @Get('finds/:title')
   async getQuestionListByTitle(
     @Param('title') title: string,
@@ -141,7 +122,7 @@ export class QuestionsController {
         .json({ error: 'Internal server error' });
     }
   }
-  
+
   // TODO: use UserGuard to check if user is the owner of the question
   @Put(':id')
   async updateOneQuestion(

--- a/BE/src/questions/questions.service.spec.ts
+++ b/BE/src/questions/questions.service.spec.ts
@@ -1,9 +1,44 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuestionsService } from './questions.service';
 import { PrismaService } from '../prisma.service';
+import { QuestionListOptionsDto } from './dto/read-question-list-options.dto';
+import { ReadQuestionListDto } from './dto/read-question-list.dto';
 
 describe('QuestionsService', () => {
   let service: QuestionsService;
+  let mockQuestions: ReadQuestionListDto[];
+
+  const tags = ['siteA', 'siteB', 'siteC', 'siteD'];
+  const programmingLanguages = [
+    'C++',
+    'JavaScript',
+    'Python',
+    'Ruby',
+    'Golf',
+    'Fortran',
+  ];
+
+  function getRandomInt(min: number, max: number) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  function getRandomElement(array: any[]) {
+    return array[Math.floor(Math.random() * array.length)];
+  }
+
+  beforeAll(() => {
+    mockQuestions = Array.from({ length: 20 }, (_, i) => ({
+      id: i + 1,
+      title: `Question ${i + 1}`,
+      nickname: `name ${i + 1}`,
+      tag: getRandomElement(tags),
+      isAdopted: Boolean(i % 2),
+      likeCount: getRandomInt(1, 100),
+      viewCount: getRandomInt(1, 100),
+      createdAt: new Date(2022, i % 12, getRandomInt(1, 28)),
+      programmingLanguage: getRandomElement(programmingLanguages),
+    }));
+  });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,5 +50,125 @@ describe('QuestionsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should filter by tag', async () => {
+    const options: QuestionListOptionsDto = {
+      tag: getRandomElement(tags),
+    };
+
+    const filteredQuestions = mockQuestions.filter(
+      (question) => question.tag === options.tag,
+    );
+    jest
+      .spyOn(service, 'readQuestionList')
+      .mockResolvedValue(filteredQuestions);
+
+    const result = await service.readQuestionList(options);
+    expect(result).toEqual(filteredQuestions);
+  });
+
+  it('should filter by programming language', async () => {
+    const options: QuestionListOptionsDto = {
+      programmingLanguage: getRandomElement(programmingLanguages),
+    };
+
+    const filteredQuestions = mockQuestions.filter(
+      (question) =>
+        question.programmingLanguage === options.programmingLanguage,
+    );
+    jest
+      .spyOn(service, 'readQuestionList')
+      .mockResolvedValue(filteredQuestions);
+
+    const result = await service.readQuestionList(options);
+    expect(result).toEqual(filteredQuestions);
+  });
+
+  it('should filter by isAdopted', async () => {
+    const options: QuestionListOptionsDto = {
+      isAdopted: Boolean(getRandomInt(0, 1)),
+    };
+
+    const filteredQuestions = mockQuestions.filter(
+      (question) => question.isAdopted === options.isAdopted,
+    );
+    jest
+      .spyOn(service, 'readQuestionList')
+      .mockResolvedValue(filteredQuestions);
+
+    const result = await service.readQuestionList(options);
+    expect(result).toEqual(filteredQuestions);
+  });
+
+  it('should filter by tag, programming language, and isAdopted', async () => {
+    const options: QuestionListOptionsDto = {
+      tag: getRandomElement(tags),
+      programmingLanguage: getRandomElement(programmingLanguages),
+      isAdopted: Boolean(getRandomInt(0, 1)),
+    };
+
+    const filteredQuestions = mockQuestions.filter(
+      (question) =>
+        question.tag === options.tag &&
+        question.programmingLanguage === options.programmingLanguage &&
+        question.isAdopted === options.isAdopted,
+    );
+    jest
+      .spyOn(service, 'readQuestionList')
+      .mockResolvedValue(filteredQuestions);
+
+    const result = await service.readQuestionList(options);
+    expect(result).toEqual(filteredQuestions);
+  });
+
+  it('should filter by tag, programming language, and isAdopted and should sort by createdAt, viewCount, and likeCount', async () => {
+    const options: QuestionListOptionsDto = {
+      tag: getRandomElement(tags),
+      programmingLanguage: getRandomElement(programmingLanguages),
+      isAdopted: Boolean(getRandomInt(0, 1)),
+      sortByCreatedAt: 'asc',
+      sortByViewCount: 'desc',
+      sortByLikeCount: 'asc',
+    };
+
+    const filteredQuestions = mockQuestions
+      .filter(
+        (question) =>
+          question.tag === options.tag &&
+          question.programmingLanguage === options.programmingLanguage &&
+          question.isAdopted === options.isAdopted,
+      )
+      .sort((a, b) => {
+        if (options.sortByCreatedAt === 'asc') {
+          return a.createdAt.getTime() - b.createdAt.getTime();
+        } else if (options.sortByCreatedAt === 'desc') {
+          return b.createdAt.getTime() - a.createdAt.getTime();
+        }
+        return 0;
+      })
+      .sort((a, b) => {
+        if (options.sortByViewCount === 'asc') {
+          return a.viewCount - b.viewCount;
+        } else if (options.sortByViewCount === 'desc') {
+          return b.viewCount - a.viewCount;
+        }
+        return 0;
+      })
+      .sort((a, b) => {
+        if (options.sortByLikeCount === 'asc') {
+          return a.likeCount - b.likeCount;
+        } else if (options.sortByLikeCount === 'desc') {
+          return b.likeCount - a.likeCount;
+        }
+        return 0;
+      });
+
+    jest
+      .spyOn(service, 'readQuestionList')
+      .mockResolvedValue(filteredQuestions);
+
+    const result = await service.readQuestionList(options);
+    expect(result).toEqual(filteredQuestions);
   });
 });


### PR DESCRIPTION
### 관련 이슈
#19 #70 

### 구현한 기능

URL | URI | Method | Description | Request Body | Response Body | 비고 (Status Code 외)
-- | -- | -- | -- | -- | -- | --
/questions | /questions/lists | GET | 페이지 별 질문 리스트 | Querystring으로 값 전달  tag, programmingLanguage, isAdopted, page, sortByCreatedAt,sortByViewCount,sortByLikeCount  page는 1, sortByCreatedAt는 desc가 기본값임 일부 Querystring만 전달해도 됨 | [{ id, title, nickname, tag(문제 사이트), createdAt, programmingLanguage, isAdopted, viewCount, likeCount }, ...] | 200, 500

- read-question-list-options.dto.ts 작성
- querystring으로 넘어온 인수들 타입 캐스팅
- where에 OR을 사용함으로 써 필터링하지 않는 기준이면 undefined를 넘겨주어 해당 기준을 where에 사용하지 않도록 함 (https://www.prisma.io/docs/concepts/components/prisma-client/null-and-undefined)
