### PR TITLE
작성 중인 글 서버에 주기적으로 저장 API

### DIFF
--- a/BE/prisma/schema.prisma
+++ b/BE/prisma/schema.prisma
@@ -88,21 +88,22 @@ model Question {
 }
 
 model User {
-  Id             Int              @id @default(autoincrement())
-  UserId         String?          @unique(map: "UserId") @db.VarChar(255)
-  Password       String?          @db.VarChar(255)
-  Nickname       String?          @db.VarChar(255)
-  ProfileImage   String?          @db.VarChar(255)
-  Points         Int?             @default(0)
-  CreatedAt      DateTime?        @default(now()) @db.DateTime(0)
-  UpdatedAt      DateTime?        @default(now()) @db.DateTime(0)
-  DeletedAt      DateTime?        @db.DateTime(0)
-  Answer         Answer[]
-  Delete_History Delete_History[]
-  LikeInfo       LikeInfo[]
-  Point_History  Point_History[]
-  Question       Question[]
-  User_Item      User_Item[]
+  Id                 Int                  @id @default(autoincrement())
+  UserId             String?              @unique(map: "UserId") @db.VarChar(255)
+  Password           String?              @db.VarChar(255)
+  Nickname           String?              @db.VarChar(255)
+  ProfileImage       String?              @db.VarChar(255)
+  Points             Int?                 @default(0)
+  CreatedAt          DateTime?            @default(now()) @db.DateTime(0)
+  UpdatedAt          DateTime?            @default(now()) @db.DateTime(0)
+  DeletedAt          DateTime?            @db.DateTime(0)
+  Answer             Answer[]
+  Delete_History     Delete_History[]
+  LikeInfo           LikeInfo[]
+  Point_History      Point_History[]
+  Question           Question[]
+  Question_Temporary Question_Temporary[]
+  User_Item          User_Item[]
 }
 
 model User_Item {
@@ -114,5 +115,19 @@ model User_Item {
   Item         Item?     @relation(fields: [ItemId], references: [Id], onDelete: NoAction, onUpdate: NoAction, map: "User_Item_ibfk_2")
 
   @@index([ItemId], map: "ItemId")
+  @@index([UserId], map: "UserId")
+}
+
+model Question_Temporary {
+  Id                  Int       @id @default(autoincrement())
+  UserId              Int?
+  Title               String?   @db.VarChar(255)
+  Content             String?   @db.Text
+  Tag                 String?   @db.VarChar(255)
+  ProgrammingLanguage String?   @db.VarChar(255)
+  OriginalLink        String?   @db.VarChar(255)
+  CreatedAt           DateTime? @default(now()) @db.DateTime(0)
+  User                User?     @relation(fields: [UserId], references: [Id], onDelete: NoAction, onUpdate: NoAction, map: "Question_Temporary_ibfk_1")
+
   @@index([UserId], map: "UserId")
 }

--- a/BE/src/questions/dto/update-question-draft.dto.ts
+++ b/BE/src/questions/dto/update-question-draft.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateQuestionDto } from './create-question.dto';
+
+export class UpdateQuestionDraftDto extends PartialType(CreateQuestionDto) {}

--- a/BE/src/questions/questions.controller.spec.ts
+++ b/BE/src/questions/questions.controller.spec.ts
@@ -3,6 +3,7 @@ import { QuestionsController } from './questions.controller';
 import { PrismaService } from '../prisma.service';
 import { QuestionsService } from './questions.service';
 import { ReadQuestionListDto } from './dto/read-question-list.dto';
+import { HttpStatus } from '@nestjs/common';
 
 describe('QuestionsController', () => {
   let controller: QuestionsController;
@@ -71,7 +72,7 @@ describe('QuestionsController', () => {
         response as any, // Type casting for simplicity
       );
 
-      expect(response.status).toHaveBeenCalledWith(200);
+      expect(response.status).toHaveBeenCalledWith(HttpStatus.OK);
       expect(response.json).toHaveBeenCalledWith(mockQuestionList);
     });
 
@@ -87,9 +88,71 @@ describe('QuestionsController', () => {
 
       await controller.getQuestionList({}, response as any);
 
-      expect(response.status).toHaveBeenCalledWith(500);
+      expect(response.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
       expect(response.json).toHaveBeenCalledWith({
         error: 'Internal server error',
+      });
+    });
+  });
+
+  describe('createDraft', () => {
+    it('should create a draft', async () => {
+      const mockDraftId = 1;
+      jest
+        .spyOn(service, 'createOneQuestionDraft')
+        .mockResolvedValue(mockDraftId);
+
+      const response = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.createDraft(response as any);
+
+      expect(response.status).toHaveBeenCalledWith(HttpStatus.CREATED);
+      expect(response.json).toHaveBeenCalledWith({
+        message: 'Draft created successfully',
+        id: mockDraftId,
+      });
+    });
+  });
+
+  describe('updateDraft', () => {
+    it('should update a draft', async () => {
+      const mockDraftId = 1;
+      jest.spyOn(service, 'updateOneQuestionDraft').mockResolvedValue();
+
+      const response = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.updateDraft(mockDraftId, {}, response as any);
+
+      expect(response.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(response.json).toHaveBeenCalledWith({
+        message: 'Draft updated successfully',
+      });
+    });
+  });
+
+  describe('deleteDraft', () => {
+    it('should delete a draft', async () => {
+      const mockDraftId = 1;
+      jest.spyOn(service, 'deleteOneQuestionDraft').mockResolvedValue();
+
+      const response = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.deleteDraft(mockDraftId, response as any);
+
+      expect(response.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(response.json).toHaveBeenCalledWith({
+        message: 'Draft deleted successfully',
       });
     });
   });

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   Put,
   Res,
+  HttpException,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { QuestionsService } from './questions.service';
@@ -17,6 +18,7 @@ import { CreateQuestionDto } from './dto/create-question.dto';
 import { ReadQuestionListDto } from './dto/read-question-list.dto';
 import { QuestionListOptionsDto } from './dto/read-question-list-options.dto';
 import { UpdateQuestionDto } from './dto/update-question.dto';
+import { UpdateQuestionDraftDto } from './dto/update-question-draft.dto';
 
 @Controller('questions')
 export class QuestionsController {
@@ -150,6 +152,74 @@ export class QuestionsController {
       return res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .json({ error: 'Internal server error' });
+    }
+  }
+
+  // TODO: Use UserGuard to obtain the user ID and associate it with the question
+  @Post('drafts')
+  async createDraft(@Res() res: Response) {
+    try {
+      const questionId = await this.questionsService.createOneQuestionDraft(1);
+
+      return res
+        .status(HttpStatus.CREATED)
+        .json({ message: 'Draft created successfully', id: questionId });
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Internal server error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // TODO: Use UserGuard to obtain the user ID and associate it with the question
+  @Put('drafts/:id')
+  async updateDraft(
+    @Param('id') id: number,
+    @Body() updateQuestionDraftDto: UpdateQuestionDraftDto,
+    @Res() res: Response,
+  ) {
+    try {
+      await this.questionsService.updateOneQuestionDraft(
+        id,
+        1,
+        updateQuestionDraftDto,
+      );
+
+      return res
+        .status(HttpStatus.OK)
+        .json({ message: 'Draft updated successfully' });
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Internal server error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // TODO: Use UserGuard to obtain the user ID and associate it with the question
+  @Delete('drafts/:id')
+  async deleteDraft(@Param('id') id: number, @Res() res: Response) {
+    try {
+      await this.questionsService.deleteOneQuestionDraft(id, 1);
+
+      return res
+        .status(HttpStatus.OK)
+        .json({ message: 'Draft deleted successfully' });
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Internal server error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 }

--- a/BE/src/questions/questions.service.spec.ts
+++ b/BE/src/questions/questions.service.spec.ts
@@ -3,6 +3,7 @@ import { QuestionsService } from './questions.service';
 import { PrismaService } from '../prisma.service';
 import { QuestionListOptionsDto } from './dto/read-question-list-options.dto';
 import { ReadQuestionListDto } from './dto/read-question-list.dto';
+import { UpdateQuestionDraftDto } from './dto/update-question-draft.dto';
 
 describe('QuestionsService', () => {
   let service: QuestionsService;
@@ -170,5 +171,64 @@ describe('QuestionsService', () => {
 
     const result = await service.readQuestionList(options);
     expect(result).toEqual(filteredQuestions);
+  });
+
+  describe('createOneQuestionDraft', () => {
+    it('should create a question draft', async () => {
+      const mockUserId = 1;
+      const mockDraftId = 1;
+
+      jest
+        .spyOn(service, 'createOneQuestionDraft')
+        .mockResolvedValue(mockDraftId);
+
+      const result = await service.createOneQuestionDraft(mockUserId);
+
+      expect(result).toEqual(mockDraftId);
+    });
+  });
+
+  describe('updateOneQuestionDraft', () => {
+    it('should update a question draft', async () => {
+      const mockDraftId = 1;
+      const mockUserId = 1;
+      const mockUpdateQuestionDraftDto: UpdateQuestionDraftDto = {
+        title: 'Updated Title',
+        content: 'Updated Content',
+        tag: 'Updated Tag',
+        programmingLanguage: 'Updated Language',
+        originalLink: 'Updated Link',
+      };
+
+      jest.spyOn(service, 'updateOneQuestionDraft').mockResolvedValue();
+
+      await service.updateOneQuestionDraft(
+        mockDraftId,
+        mockUserId,
+        mockUpdateQuestionDraftDto,
+      );
+
+      expect(service.updateOneQuestionDraft).toHaveBeenCalledWith(
+        mockDraftId,
+        mockUserId,
+        mockUpdateQuestionDraftDto,
+      );
+    });
+  });
+
+  describe('deleteOneQuestionDraft', () => {
+    it('should delete a question draft', async () => {
+      const mockDraftId = 1;
+      const mockUserId = 1;
+
+      jest.spyOn(service, 'deleteOneQuestionDraft').mockResolvedValue();
+
+      await service.deleteOneQuestionDraft(mockDraftId, mockUserId);
+
+      expect(service.deleteOneQuestionDraft).toHaveBeenCalledWith(
+        mockDraftId,
+        mockUserId,
+      );
+    });
   });
 });

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -4,6 +4,7 @@ import { ReadQuestionDto } from './dto/read-question.dto';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { ReadQuestionListDto } from './dto/read-question-list.dto';
 import { QuestionListOptionsDto } from './dto/read-question-list-options.dto';
+import { UpdateQuestionDraftDto } from './dto/update-question-draft.dto';
 
 @Injectable()
 export class QuestionsService {
@@ -217,6 +218,60 @@ export class QuestionsService {
       return true;
     } catch (error) {
       return false;
+    }
+  }
+
+  async createOneQuestionDraft(userId: number): Promise<number> {
+    try {
+      const draft = await this.prisma.question_Temporary.create({
+        data: {
+          User: {
+            connect: {
+              Id: userId,
+            },
+          },
+        },
+      });
+      return draft.Id;
+    } catch (error) {
+      throw new Error('Failed to create question draft');
+    }
+  }
+
+  async updateOneQuestionDraft(
+    id: number,
+    userId: number,
+    updateQuestionDraftDto: UpdateQuestionDraftDto,
+  ): Promise<void> {
+    try {
+      await this.prisma.question_Temporary.update({
+        where: {
+          Id: id,
+          UserId: userId,
+        },
+        data: {
+          Title: updateQuestionDraftDto.title,
+          Content: updateQuestionDraftDto.content,
+          Tag: updateQuestionDraftDto.tag,
+          ProgrammingLanguage: updateQuestionDraftDto.programmingLanguage,
+          OriginalLink: updateQuestionDraftDto.originalLink,
+        },
+      });
+    } catch (error) {
+      throw new Error('Failed to update question draft');
+    }
+  }
+
+  async deleteOneQuestionDraft(id: number, userId: number): Promise<void> {
+    try {
+      await this.prisma.question_Temporary.delete({
+        where: {
+          Id: id,
+          UserId: userId,
+        },
+      });
+    } catch (error) {
+      throw new Error('Failed to delete question draft');
     }
   }
 }


### PR DESCRIPTION
### 관련 이슈
#24 

### 구현한 기능

URL | URI | Method | Description | Querystring | Request Body | Response Body | 비고 (Status Code 외)
-- | -- | -- | -- | -- | -- | -- | --
/questions | /questions/drafts | POST | 임시글 생성 |   |   | {id} | 201, 500
/questions | /questions/drafts/:id | PUT | 임시글 업데이트 |   | { title, content, tag, programmingLanguage, originalLink } |   | 200, 500
/questions | /question/drafts/:id | DELETE | 임시글 삭제 |   |   |   | 200


- Question_Temporary Table 생성
- update-question-draft.dto.ts 작성
- 임시 게시글 생성 (POST)
- 임시 게시글 수정 (PUT)
- 임시 게시글 삭제 (DELETE)
