### PR TITLE
프론트엔드 build 에러 해결

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -1577,6 +1577,12 @@
         "@types/draft-js": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2283,6 +2289,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/core-js": {
       "version": "3.33.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
@@ -2291,6 +2303,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/cross-fetch": {
@@ -2470,6 +2508,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/draft-js": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
@@ -2504,6 +2552,33 @@
       "peerDependencies": {
         "draft-js": "^0.11.x",
         "immutable": "3.x.x || 4.x.x"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.590",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.590.tgz",
+      "integrity": "sha512-hohItzsQcG7/FBsviCYMtQwUSWvVF7NVqPOnJCErWsAshsP/CR2LAXdmq276RbESNdhxiAq5/vRo1g2pxGXVww==",
+      "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -4041,6 +4116,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "node_modules/linkify-it": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -4207,6 +4288,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -4225,6 +4316,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "dev": true
     },
     "node_modules/npm-run-path": {
       "version": "5.1.0",
@@ -5609,6 +5706,20 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-svgr": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.2.0.tgz",
+      "integrity": "sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.5",
+        "@svgr/core": "^8.1.0",
+        "@svgr/plugin-jsx": "^8.1.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.6.0 || 3 || 4 || 5"
       }
     },
     "node_modules/webidl-conversions": {

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { MainHeader, MainNav } from './components';
-import { MainPage, QuestionCreationPage } from './pages';
+import { MainPage } from './pages';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './styles/theme';
 
@@ -13,10 +13,11 @@ function App() {
         <Router>
           <Routes>
             <Route path="/" element={<MainPage />} />
-            <Route
+            {/* ⚠️ QuestionCreationPage 컴포넌트 생성 후 주석 해제 필요 */}
+            {/* <Route 
               path="/question/create/:id"
               element={<QuestionCreationPage />}
-            />
+            /> */}
           </Routes>
         </Router>
       </ThemeProvider>

--- a/FE/src/components/Pagination/Pagination.tsx
+++ b/FE/src/components/Pagination/Pagination.tsx
@@ -83,6 +83,7 @@ export function Pagination({
       <ul className="page-list">
         {getCurrentNum(wholePageCount, currentPage, splitNumber).map((i) => (
           <span
+            key={i}
             className={i === currentPage + 1 ? 'current' : ''}
             onClick={() => handlePageItem(i - 1)}
           >

--- a/FE/src/components/QuestionList/QuestionList.styles.ts
+++ b/FE/src/components/QuestionList/QuestionList.styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 interface TagProps {
-  tag: string;
+  $tag: string;
 }
 
 export const Header = styled.div`
@@ -91,8 +91,8 @@ export const ItemAside = styled.div`
 `;
 
 export const Tag = styled.div<TagProps>`
-  color: ${({ tag }) => {
-    switch (tag) {
+  color: ${({ $tag }) => {
+    switch ($tag) {
       case 'programemrs':
         return '';
       case 'leetcode':

--- a/FE/src/components/QuestionList/QuestionList.tsx
+++ b/FE/src/components/QuestionList/QuestionList.tsx
@@ -24,9 +24,6 @@ import {
 const LAST_PAGINATION_PAGE = 11;
 const PAGINATION_SPLIT_NUMBER = 10;
 
-const LAST_PAGINATION_PAGE = 11;
-const PAGINATION_SPLIT_NUMBER = 10;
-
 interface ItemData {
   id: number;
   title: string;

--- a/FE/src/components/QuestionList/QuestionList.tsx
+++ b/FE/src/components/QuestionList/QuestionList.tsx
@@ -13,6 +13,7 @@ import {
   Details,
   AdoptBadge,
   Author,
+  Date,
   ItemAside,
   Tag,
   ProgrammingLanguage,

--- a/FE/src/components/QuestionList/QuestionList.tsx
+++ b/FE/src/components/QuestionList/QuestionList.tsx
@@ -75,7 +75,7 @@ export function Item({ itemData }: { itemData: ItemData }) {
         </Details>
       </ItemMain>
       <ItemAside>
-        <Tag tag={tag}>{tag}</Tag>
+        <Tag $tag={tag}>{tag}</Tag>
         <ProgrammingLanguage>{programmingLanguage}</ProgrammingLanguage>
         <ViewCount>
           <img src={eyeIcon} />

--- a/FE/src/components/UniqueQuestions/UniqueQuestions.styles.ts
+++ b/FE/src/components/UniqueQuestions/UniqueQuestions.styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 interface ItemProps {
-  bgColor: string;
+  $bgcolor: string;
 }
 
 export const Item = styled.div<ItemProps>`
@@ -13,7 +13,7 @@ export const Item = styled.div<ItemProps>`
   padding: 1.2rem 1rem;
   border-radius: 0.5rem;
   box-shadow: -0.2rem 0.2rem 0.2rem #00000025;
-  background-color: ${({ bgColor }) => bgColor};
+  background-color: ${({ $bgcolor }) => $bgcolor};
   color: var(--color-grayscale-white);
   transition: all 0.2s ease-in;
   cursor: pointer;

--- a/FE/src/components/UniqueQuestions/UniqueQuestions.tsx
+++ b/FE/src/components/UniqueQuestions/UniqueQuestions.tsx
@@ -23,7 +23,7 @@ function Item({ type, title: questionTime, url }: Item) {
   const { title, emoji, color } = typeInfo[type];
 
   return (
-    <S.Item bgColor={color} data-url={url}>
+    <S.Item $bgcolor={color} data-url={url}>
       <h3>{title}</h3>
       <div>{questionTime}</div>
       <span>{emoji}</span>
@@ -34,8 +34,8 @@ function Item({ type, title: questionTime, url }: Item) {
 export function UniqueQuestions({ questions }: { questions: Item[] }) {
   return (
     <S.UniqueQuestions>
-      {questions.map(({ type, title, url }) => (
-        <Item type={type} title={title} url={url} />
+      {questions.map(({ type, title, url }, idx) => (
+        <Item key={idx} type={type} title={title} url={url} />
       ))}
     </S.UniqueQuestions>
   );

--- a/FE/src/main.tsx
+++ b/FE/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/index.css';

--- a/FE/src/pages/MainPage/MainPage.tsx
+++ b/FE/src/pages/MainPage/MainPage.tsx
@@ -5,7 +5,6 @@ import {
 } from '../../components';
 import { UniqueQuestionItem as Question } from '../../types/type';
 import dummyUniqueQuestions from '../../assets/uniqueQuestions.json';
-import dummyQuestionList from '../../assets/questionlistMockdata.json';
 import { Main } from './MainPage.styles';
 
 export default function MainPage() {
@@ -14,7 +13,7 @@ export default function MainPage() {
       <div className="inner">
         <div>
           <UniqueQuestions questions={dummyUniqueQuestions as Question[]} />
-          <QuestionList itemDatas={dummyQuestionList} />
+          <QuestionList />
         </div>
         <aside>
           <img

--- a/FE/src/pages/index.ts
+++ b/FE/src/pages/index.ts
@@ -1,4 +1,3 @@
 import MainPage from './MainPage/MainPage';
-import QuestionCreationPage from './QuestionCreationPage/QuestionCreationPage';
 
-export { MainPage, QuestionCreationPage };
+export { MainPage };

--- a/FE/vite.config.js
+++ b/FE/vite.config.js
@@ -13,4 +13,5 @@ export default defineConfig({
     },
   },
   plugins: [react(), svgr()],
+  build: { chunkSizeWarningLimit: 1600 },
 });


### PR DESCRIPTION
## 관련 이슈

Close #97 

## 구현 사항

### 🚨 fix: build 에러 해결

#### 문제 원인

PR 업로드 및 코드 리뷰시 build 테스트를 하지 않아 발생한 버그.
다음과 같은 사항들이 버그의 원인이었다.

- 사용하지 않는 요소에 대한 import 존재
- 중복된 상수 존재
- 사용하지 않는 props 존재

#### 해결

각 버그 원인을 해결해주었다.
또한 앞으로 PR을 올릴 땐 반드시 build 테스트 후에 올리고,
코드 리뷰를 할 때도 반드시 로컬로 pull을 해서 빌드 상의 에러가 없는지 확인해주는 절차가 필요할 듯 하다.
@BaeJ1H021 @MayOwall 

<br/>

### 🚨 fix: 질문 리스트 아이템 날짜가 잘못 랜더링 되는 버그 수정

#### 원인

styled-component의 Date 요소를 import 하지 않아 발생한 버그
원래 import를 하지 않으면 없는 요소라며 에러가 발생했어야 했지만,
window의 Date 객체와 이름이 같아 브라우저가 에러라고 인식하지 못해 생긴 버그였다.

#### 해결

Date 요소를 정상적으로 import

<br/>

### chore: vite 환경 설정 변경 

build 후 파일이 vite 권장 파일 크기 제한보다 커서 경고가 발생하였다.
경고를 없애기 위해 vite 환경 설정 중 chunkSizeWarningLimit을 1600으로 변경해주었다.

