### PR TITLE
ENV로드 방식 변경

### DIFF
--- a/BE/src/auth/strategies/jwt.strategy.ts
+++ b/BE/src/auth/strategies/jwt.strategy.ts
@@ -3,13 +3,17 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { AuthService } from '../auth.service';
 import { JwtPayloadDto } from '../DTO/jwt-payload.dto';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
-  constructor(private readonly authService: AuthService) {
+  constructor(
+    private readonly authService: AuthService,
+    configService: ConfigService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.JWT_SECRET,
+      secretOrKey: configService.get('JWT_SECRET'),
     });
   }
 


### PR DESCRIPTION
.env를 읽어오는 방식의 차이로 docker에서 실행하면 jwt 관련 코드 실행단계에서 env가 로드되어 있지 않는다.
읽는 방식 process.env에서 configService 주입 후 configService.get('JWT_SECRET')로 변경