### PR TITLE
질문 리스트 레이아웃 GET API 수정

### DIFF
--- a/FE/src/api/index.ts
+++ b/FE/src/api/index.ts
@@ -1,13 +1,26 @@
 import axios from 'axios';
 const { VITE_BASE_URL } = import.meta.env;
 
+interface Options {
+  page?: number;
+  tag?: string;
+  ProgrammingLanguage?: string;
+  isAdopted?: 1 | 0;
+  sortByCreatedAt?: 'desc' | 'asc';
+  sortByViewCount?: 'desc' | 'asc';
+  [key: string]: number | string | undefined;
+}
+
 const instance = axios.create({
   baseURL: VITE_BASE_URL,
 });
 
-export const getQuestionList = async (page: number) => {
+export const getQuestionList = async (options: Options) => {
   try {
-    const url = `/api/questions/lists/${page}`;
+    const queryString = Object.keys(options)
+      .map((option) => `${option}=${options[option] as string}`)
+      .join('&');
+    const url = `/api/questions/lists/?${queryString}`;
     const { status, data } = await instance.get(url);
     if (status !== 200) {
       throw new Error();

--- a/FE/src/components/QuestionList/QuestionList.tsx
+++ b/FE/src/components/QuestionList/QuestionList.tsx
@@ -97,7 +97,7 @@ export function QuestionList() {
   );
 
   const getCurrentQuestionListData = async () => {
-    const data = await getQuestionList(currentPage + 1);
+    const data = await getQuestionList({ page: currentPage + 1 });
     setQuestionListData(data);
   };
 


### PR DESCRIPTION
## 관련 이슈

Close #109 

## 구현한 기능

### fix: 질문 리스트 레이아웃 GET API 수정

기존의 질문 리스트를 불러오는 API의 option을 path 방식에서 queryString 방식으로 변경해주었습니다.
이제 page 옵션 뿐만 아니라 각종 옵션들을 필터링, 정렬하여 질문 리스트 데이터를 불러올 수 있습니다.

## 논의할 사항
.