### PR TITLE
질문 리스트 API 기능 확장

### DIFF
--- a/BE/src/questions/dto/read-question-list-options.dto.ts
+++ b/BE/src/questions/dto/read-question-list-options.dto.ts
@@ -33,4 +33,8 @@ export class QuestionListOptionsDto {
   @IsNumber()
   @Min(1)
   page?: number = 1;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
 }

--- a/BE/src/questions/questions.controller.ts
+++ b/BE/src/questions/questions.controller.ts
@@ -47,9 +47,10 @@ export class QuestionsController {
     @Res() res: Response,
   ) {
     try {
-      const questionList: ReadQuestionListDto[] =
+      const { questions, totalQuestions } =
         await this.questionsService.readQuestionList(options);
-      return res.status(HttpStatus.OK).json(questionList);
+      const totalPage = Math.ceil(totalQuestions / 10);
+      return res.status(HttpStatus.OK).json({ questions, totalPage });
     } catch (error) {
       return res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -173,6 +173,11 @@ export class QuestionsService {
       where: {
         OR: whereConditions.length > 0 ? whereConditions : undefined,
         DeletedAt: null,
+        Title: options.title
+          ? {
+              contains: options.title,
+            }
+          : undefined,
       },
       orderBy: orderByConditions,
       select: {

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -144,7 +144,7 @@ export class QuestionsService {
 
   async readQuestionList(
     options: QuestionListOptionsDto,
-  ): Promise<ReadQuestionListDto[]> {
+  ): Promise<{ questions: ReadQuestionListDto[]; totalQuestions: number }> {
     const {
       tag,
       programmingLanguage,
@@ -199,17 +199,32 @@ export class QuestionsService {
       skip: (page - 1) * pageSize,
     });
 
-    return questions.map((question) => ({
-      id: question.Id,
-      title: question.Title,
-      nickname: question.User.Nickname,
-      tag: question.Tag,
-      createdAt: question.CreatedAt,
-      programmingLanguage: question.ProgrammingLanguage,
-      isAdopted: question.IsAdopted,
-      viewCount: question.ViewCount,
-      likeCount: question.LikeCount,
-    }));
+    const total = await this.prisma.question.count({
+      where: {
+        OR: whereConditions.length > 0 ? whereConditions : undefined,
+        DeletedAt: null,
+        Title: options.title
+          ? {
+              contains: options.title,
+            }
+          : undefined,
+      },
+    });
+
+    return {
+      questions: questions.map((question) => ({
+        id: question.Id,
+        title: question.Title,
+        nickname: question.User.Nickname,
+        tag: question.Tag,
+        createdAt: question.CreatedAt,
+        programmingLanguage: question.ProgrammingLanguage,
+        isAdopted: question.IsAdopted,
+        viewCount: question.ViewCount,
+        likeCount: question.LikeCount,
+      })),
+      totalQuestions: total,
+    };
   }
 
   async findQuestionByTitle(


### PR DESCRIPTION
### 관련 이슈
#153 

### 구현한 기능
- 질문 리스트 API에 검색 기능을 추가했습니다.
- Querystring으로 title을 넘겨주면 title을 포함하는 질문의 리스트를 반환합니다.
- controller의 반환 값을 변경했습니다. { questions: 질문들, totalPage: 숫자} 입니다.

### 당부의 말씀
- 호환성을 위해 질문 검색 API는 삭제하지 않았습니다만 추후 삭제할 예정이니 검색 기능은 질문 리스트 API를 사용해주세요