### PR TITLE
문제 답변 기능 관련 컴포넌트 구현(QuestionAnswerFormCard 외 3개)

### DIFF
--- a/FE/src/components/QuestionAnswerCard/QuestionAnswerCard.styles.ts
+++ b/FE/src/components/QuestionAnswerCard/QuestionAnswerCard.styles.ts
@@ -1,0 +1,85 @@
+import styled from 'styled-components';
+
+export const Container = styled.article`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
+
+export const Inner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  width: 100%;
+  min-width: 900px;
+  max-width: ${({ theme }) => theme.maxWidth};
+  height: 100%;
+  padding: 1rem 0;
+`;
+
+interface HeaderProps {
+  isadopted: boolean;
+}
+
+export const Header = styled.div<HeaderProps>`
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+
+  height: 100%;
+  align-items: center;
+  color: ${({ theme }) => theme.color.mainColor.blueMain};
+  border-bottom: ${({ isadopted }) => (isadopted ? '0.25rem solid' : 'none')};
+
+  > div {
+    font-weight: 900;
+    font-size: 4rem;
+    margin-bottom: 1rem;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    margin-top: 2rem;
+  }
+`;
+
+export const AdoptedBadge = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  position: absolute;
+  left: 4rem;
+  bottom: 1rem;
+
+  > span {
+    margin-top: 0.1rem;
+    ${({ theme }) => theme.font.bold16}
+  }
+`;
+
+export const Content = styled.p`
+  ${({ theme }) => theme.font.medium16};
+`;
+
+export const QuestionInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const TagInfo = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+export const CreateInfo = styled.div``;
+
+export const LikeInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+
+  > svg {
+    cursor: pointer;
+  }
+`;

--- a/FE/src/components/QuestionAnswerCard/QuestionAnswerCard.tsx
+++ b/FE/src/components/QuestionAnswerCard/QuestionAnswerCard.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { KebabIcon, LikeIcon, CheckCircleIcon } from '../../assets/icons';
+import { getFormalizedDate } from '../..//hooks';
+import { QuestionAnswerCardProps } from '../../types/type';
+import {
+  Container,
+  Inner,
+  Header,
+  Content,
+  QuestionInfo,
+  CreateInfo,
+  LikeInfo,
+  AdoptedBadge,
+} from './QuestionAnswerCard.styles';
+
+const QuestionAnswerCard = ({ cardData }: QuestionAnswerCardProps) => {
+  const {
+    content,
+    nickname,
+    createdAt,
+    isAdopted,
+    isLiked: isLikedInitial,
+  } = cardData;
+  const [isLiked, setIsLiked] = useState(isLikedInitial);
+
+  useEffect(() => {
+    // useDidMoundEffect로 변경 & API 로직 구현
+  }, [isLiked]);
+
+  return (
+    <Container>
+      <Inner>
+        <Header isadopted={isAdopted}>
+          <div>A</div>
+          {isAdopted && (
+            <AdoptedBadge>
+              <CheckCircleIcon width={32} height={32} />
+              <span>질문자 채택</span>
+            </AdoptedBadge>
+          )}
+          <KebabIcon />
+        </Header>
+        <Content>{content}</Content>
+        <QuestionInfo>
+          <CreateInfo>
+            {nickname} {getFormalizedDate(createdAt)}
+          </CreateInfo>
+          <LikeInfo>
+            <LikeIcon
+              fill={isLiked ? '#4F60FF' : '#6E8091'}
+              onClick={() => setIsLiked((prevValue) => !prevValue)}
+            />
+          </LikeInfo>
+        </QuestionInfo>
+      </Inner>
+    </Container>
+  );
+};
+
+export default QuestionAnswerCard;

--- a/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.styles.ts
+++ b/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.styles.ts
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+export const Container = styled.section`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
+
+export const Inner = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+
+  width: 100%;
+  min-width: 900px;
+  max-width: ${({ theme }) => theme.maxWidth};
+  height: 100%;
+  padding: 2rem 0;
+
+  > div:nth-of-type(1) {
+    width: 100%;
+
+    .editor {
+      height: 10rem;
+    }
+  }
+`;
+
+export const Header = styled.header`
+  width: 100%;
+  ${({ theme }) => theme.font.bold24};
+  color: ${({ theme }) => theme.color.grayscale.black};
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  color: ${({ theme }) => theme.color.grayscale[300]};
+
+  > span {
+    ${({ theme }) => theme.font.medium14};
+  }
+
+  > div {
+    display: flex;
+    gap: 0.5rem;
+    ${({ theme }) => theme.font.medium16};
+
+    > button:first-of-type {
+      color: inherit;
+    }
+  }
+`;

--- a/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
+++ b/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { EditorState, convertToRaw } from 'draft-js';
+import draftToHtml from 'draftjs-to-html';
+import { DocumentEditor, SquareButton } from '../';
+import { QuestionAnswerFormCardProps } from 'src/types/type';
+import {
+  Container,
+  Inner,
+  Header,
+  Footer,
+} from './QuestionAnswerFormCard.styles';
+
+// ⚠️ 현재 로그인한 유저의 전역 이름을 가져오는 로직이 필요
+const GLOBAL_USER_NICKNAME = 'Snoopy';
+
+const QuestionAnswerFormCard = ({
+  handleCancel,
+  handleSubmit,
+}: QuestionAnswerFormCardProps) => {
+  const [editorState, setEditorState] = useState(EditorState.createEmpty());
+
+  const getEditorContent = () => {
+    const editorContent = draftToHtml(
+      convertToRaw(editorState.getCurrentContent()),
+    );
+    return editorContent;
+  };
+
+  const isEditorContentEmpty = (editorContent: string) => {
+    const REG = /(?<=^<p>).*(?=<\/p>)/;
+    const [content] = editorContent.match(REG) as Array<string>;
+    return !content;
+  };
+
+  const onCancelButtonClick = () => {
+    handleCancel();
+  };
+
+  const onSubmitButtonClick = () => {
+    const editorContent = getEditorContent();
+    if (isEditorContentEmpty(editorContent)) {
+      return alert('답변을 입력해 주세요');
+    }
+    handleSubmit(editorContent);
+  };
+
+  return (
+    <Container>
+      <Inner>
+        <Header>답변 작성</Header>
+        <DocumentEditor
+          editorState={editorState}
+          setEditorState={setEditorState}
+        />
+        <Footer>
+          <span>{GLOBAL_USER_NICKNAME}</span>
+          <div>
+            <button onClick={onCancelButtonClick}>답변 취소</button>
+            <SquareButton
+              content="답변 등록하기"
+              handleClick={onSubmitButtonClick}
+            />
+          </div>
+        </Footer>
+      </Inner>
+    </Container>
+  );
+};
+
+export default QuestionAnswerFormCard;

--- a/FE/src/components/QuestionAnswerRequestCard/QuestionAnswerRequestCard.styles.ts
+++ b/FE/src/components/QuestionAnswerRequestCard/QuestionAnswerRequestCard.styles.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+export const Container = styled.section`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 5rem;
+`;
+
+export const Inner = styled.div`
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  min-width: 900px;
+  max-width: ${({ theme }) => theme.maxWidth};
+  height: 100%;
+  padding: 1rem 0;
+
+  > div {
+    flex-grow: 1;
+
+    > div {
+      ${({ theme }) => theme.font.bold16}
+      color: ${({ theme }) => theme.color.grayscale[500]}
+    }
+    > span {
+      ${({ theme }) => theme.font.medium14}
+      color: ${({ theme }) => theme.color.grayscale[300]}
+    }
+  }
+
+  > button {
+    flex-shrink: 0;
+  }
+`;

--- a/FE/src/components/QuestionAnswerRequestCard/QuestionAnswerRequestCard.tsx
+++ b/FE/src/components/QuestionAnswerRequestCard/QuestionAnswerRequestCard.tsx
@@ -1,0 +1,29 @@
+import { Container, Inner } from './QuestionAnswerRequestCard.styles';
+import { QuestionAnswerRequestCardProps } from 'src/types/type';
+import { SquareButton } from '../';
+
+const ANSWER_REQUIRE_MENT = '님, 답변을 달아주세요!';
+const POINT_RULE_INFORMATION =
+  '답변하시면 포인트 10점을, 채택이 되면 포인트 10점을 추가로 더 드립니다.';
+
+const QuestionAnswerRequestCard = ({
+  nickname,
+  onAnswerButtonClick,
+}: QuestionAnswerRequestCardProps) => {
+  return (
+    <Container>
+      <Inner>
+        <div>
+          <div>
+            {nickname}
+            {ANSWER_REQUIRE_MENT}
+          </div>
+          <span>{POINT_RULE_INFORMATION}</span>
+        </div>
+        <SquareButton content="답변하기" handleClick={onAnswerButtonClick} />
+      </Inner>
+    </Container>
+  );
+};
+
+export default QuestionAnswerRequestCard;

--- a/FE/src/components/SquareButton/SquareButton.styles.ts
+++ b/FE/src/components/SquareButton/SquareButton.styles.ts
@@ -1,0 +1,35 @@
+import styled, { css } from 'styled-components';
+
+interface ContainerProps {
+  styletype: 'fill' | 'stroke';
+}
+
+const fillTypeStyle = css`
+  color: ${({ theme }) => theme.color.grayscale.white};
+  background-color: ${({ theme }) => theme.color.mainColor.blueMain};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.mainColor.blueLight};
+  }
+`;
+
+const strokeTypeStyle = css`
+  color: ${({ theme }) => theme.color.mainColor.blueMain};
+  background-color: ${({ theme }) => theme.color.grayscale.white};
+  border: 1px solid;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.grayscale[50]};
+  }
+`;
+
+export const Container = styled.button<ContainerProps>`
+  width: 17rem;
+  height: 3rem;
+  border-radius: 0.25rem;
+  ${({ theme }) => theme.font.medium16}
+  transition: 0.1s ease-in all;
+
+  ${({ styletype }) =>
+    styletype === 'fill' ? fillTypeStyle : strokeTypeStyle};
+`;

--- a/FE/src/components/SquareButton/SquareButton.tsx
+++ b/FE/src/components/SquareButton/SquareButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { SquareButtonProps } from '../../types/type.d';
+import { Container } from './SquareButton.styles';
+
+const SquareButton = ({
+  content,
+  type = 'fill',
+  handleClick,
+}: SquareButtonProps) => {
+  const onButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (handleClick) {
+      handleClick();
+    }
+  };
+
+  return (
+    <Container styletype={type} onClick={onButtonClick}>
+      {content}
+    </Container>
+  );
+};
+
+export default SquareButton;

--- a/FE/src/components/index.ts
+++ b/FE/src/components/index.ts
@@ -10,6 +10,8 @@ import { Pagination } from './Pagination/Pagination';
 import DocumentEditor from './DocumentEditor/DocumentEditor';
 import QuestionDetailContent from './QuestionDetailContent/QuestionDetailContent';
 import TagButton from './TagButton/TagButton';
+import QuestionAnswerRequestCard from './QuestionAnswerRequestCard/QuestionAnswerRequestCard';
+import SquareButton from './SquareButton/SquareButton';
 
 export {
   MainHeader,
@@ -22,4 +24,6 @@ export {
   DocumentEditor,
   QuestionDetailContent,
   TagButton,
+  QuestionAnswerRequestCard,
+  SquareButton,
 };

--- a/FE/src/components/index.ts
+++ b/FE/src/components/index.ts
@@ -12,6 +12,7 @@ import QuestionDetailContent from './QuestionDetailContent/QuestionDetailContent
 import TagButton from './TagButton/TagButton';
 import QuestionAnswerRequestCard from './QuestionAnswerRequestCard/QuestionAnswerRequestCard';
 import SquareButton from './SquareButton/SquareButton';
+import QuestionAnswerCard from './QuestionAnswerCard/QuestionAnswerCard';
 
 export {
   MainHeader,
@@ -26,4 +27,5 @@ export {
   TagButton,
   QuestionAnswerRequestCard,
   SquareButton,
+  QuestionAnswerCard,
 };

--- a/FE/src/components/index.ts
+++ b/FE/src/components/index.ts
@@ -13,6 +13,7 @@ import TagButton from './TagButton/TagButton';
 import QuestionAnswerRequestCard from './QuestionAnswerRequestCard/QuestionAnswerRequestCard';
 import SquareButton from './SquareButton/SquareButton';
 import QuestionAnswerCard from './QuestionAnswerCard/QuestionAnswerCard';
+import QuestionAnswerFormCard from './QuestionAnswerFormCard/QuestionAnswerFormCard';
 
 export {
   MainHeader,
@@ -28,4 +29,5 @@ export {
   QuestionAnswerRequestCard,
   SquareButton,
   QuestionAnswerCard,
+  QuestionAnswerFormCard,
 };

--- a/FE/src/styles/reset.css
+++ b/FE/src/styles/reset.css
@@ -129,4 +129,6 @@ table {
 }
 button {
   cursor: pointer;
+  border: none;
+  background: none;
 }

--- a/FE/src/types/type.d.ts
+++ b/FE/src/types/type.d.ts
@@ -52,3 +52,8 @@ export interface QuestionAnswerCardProps {
     isLiked: boolean;
   };
 }
+
+export interface QuestionAnswerFormCardProps {
+  handleCancel: () => void;
+  handleSubmit: (content: string) => void;
+}

--- a/FE/src/types/type.d.ts
+++ b/FE/src/types/type.d.ts
@@ -28,3 +28,14 @@ export interface TagbuttonProps {
   isInteractive?: boolean;
   handleToggle?: (isSelected: boolean) => void;
 }
+
+export interface QuestionAnswerRequestCardProps {
+  nickname: string;
+  onAnswerButtonClick: () => void;
+}
+
+export interface SquareButtonProps {
+  content: string;
+  type?: 'fill' | 'stroke';
+  handleClick?: () => void;
+}

--- a/FE/src/types/type.d.ts
+++ b/FE/src/types/type.d.ts
@@ -39,3 +39,16 @@ export interface SquareButtonProps {
   type?: 'fill' | 'stroke';
   handleClick?: () => void;
 }
+
+export interface QuestionAnswerCardProps {
+  cardData: {
+    userId: number;
+    nickname: string;
+    answerId: number;
+    content: string;
+    videoLink: unknown;
+    isAdopted: boolean;
+    createdAt: string;
+    isLiked: boolean;
+  };
+}


### PR DESCRIPTION
## 관련 이슈

Close #133 

## 구현 사항

### SquareButton 컴포넌트 구현

네모네모 빔을 맞은 버튼 컴포넌트입니다.
type을 통해 2가지 스타일을 부여할 수 있습니다. (`fill`, `stroke`)

#### 컴포넌트 구현 디자인

<img width="227" alt="image" src="https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/39552c71-4437-43c7-a6a9-1f95bf731a7a">

#### props 정보

|props|타입|필수 여부|기본 값|역할|
|:--|:--|:--|:--|:--|
|content|string|required|.|버튼 내부에 들어갈 내용|
|type|`"fill"` / `"stroke"`|optional|fill|버튼 스타일 타입|
|handleClick|() => void|optional|.|버튼 클릭시 실행할 이벤트|



<br/>
<br/>

### QuestionAnswerRequestCard 컴포넌트 구현

사용자에게 답변을 요청하는 카드 컴포넌트입니다.
답변하기 버튼을 눌러 답변하기 기능을 활성화 하는 용도 등으로 사용할 수 있습니다.

#### 컴포넌트 구현 디자인

<img width="700" alt="image" src="https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/405e8400-e623-42a0-9c83-97e93e8d54d6">

#### props 정보

|props|타입|필수 여부|기본 값|역할|
|:--|:--|:--|:--|:--|
|onAnswerButtonClick|() => void|required|.|답변하기 버튼 클릭시 실행할 이벤트|

<br/>
<br/>

### QuestionAnswerCard 컴포넌트 구현

질문 답변 내용을 보여주는 카드 컴포넌트입니다.
채택 여부에 따라 2가지 스타일을 보여줍니다.
좋아요 아이콘 클릭을 통해 좋아요 상태 관리가 가능합니다. (API 연결 X)

#### 컴포넌트 구현 디자인

<img width="700" alt="image" src="https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/536d63e9-d3ab-4984-961f-6ef30914b601">

#### props 정보

|props|타입|필수 여부|기본 값|역할|
|:--|:--|:--|:--|:--|
|cardData| {userId: number; nickname: string; answerId: number; content: string; videoLink: unknown; isAdopted: boolean; createdAt: string; isLiked: boolean;}|required|.|질문 답변 내용|


<br/>
<br/>

### QuestionAnswerFormCard 컴포넌트 구현

사용자가 답변 내용을 작성하고 등록할 수 있는 기능의 카드 컴포넌트입니다.
답변 등록 버튼 클릭시, 답변 내용이 비어있으면 답변을 작성해달라는 alert와 함께 답변이 등록되지 않습니다.
답변 내용이 들어있다면 정상적으로 답변 등록하기 이벤트가 실행됩니다.

#### 컴포넌트 구현 디자인

<img width="700" alt="image" src="https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/42534db2-4725-421c-9866-07bb12f2cf04">

#### props 정보

|props|타입|필수 여부|기본 값|역할|
|:--|:--|:--|:--|:--|
|handleCancel|() => void|required|.|답변 취소시 실행할 이벤트|
|handleSubmit|(content: string) => void|required|.|답변 등록하기 버튼 클릭시 실행할 이벤트|


<br/>
<br/>

## 논의할 사항

### DocumentEditor 컴포넌트 추상화

DocumentEditor의 컴포넌트를 더 추상화 할 필요가 있는 것 같습니다.
현재 DocumentEditor 컴포넌트를 사용하려면 컴포넌트 외부에서 해당 컴포넌트와 관련된 로직을 사용해야 하는데 (`EditorState`, `ConvertToRaw` 등),
이는 컴포넌트의 독립성을 크게 떨어트리게 된다고 개인적으로 생각이 듭니다.

해당 컴포넌트가 리소스를 더 사용하게 되는 것을 감수하더라도 DocumentEditor 내부에서 convertToRaw 등 모든 상태 관련 로직을 완료하도록 해 주는 것이 앞으로의 기술 부채를 생각해봤을 땐 더 좋은 방법이라 생각합니다.

<br/>