### PR TITLE
196 좋아요 기능이 작동하지 않음

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -6,6 +6,7 @@ import { QuestionsModule } from './questions/questions.module';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { LikesModule } from './likes/likes.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ConfigModule } from '@nestjs/config';
     QuestionsModule,
     UsersModule,
     AuthModule,
+    LikesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
     .addServer('http://algocean.site/api')
     .addServer('http://algocean.site')
     .addServer('api')
-    .addServer('')
+    .addServer('/')
     .build();
 
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);


### PR DESCRIPTION
# 관련 이슈
#196 

# 한 일
성능 테스트를 진행하던 중 좋아요 API가 swagger에 없음을 발견했습니다.
들여다보니 app.module에 LikeModule이 등록되어 있지 않았습니다.
이를 등록했습니다.

이후 로컬에서 swagger로 테스트하려 하자 문제가 발생했습니다.
Servers에서 빈 문자열을 선택하면 localhost:3000기준으로 요청이 갈거라고 예상했지만 아니었습니다.
**해결 전**
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/51262434/d19b827f-d0a0-465b-9a7e-385b3ae71a26)

**해결 후**
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/51262434/6a758ec7-d7e7-4554-9580-a33f52bf9727)

**해결 방법**
```typescript
const swaggerConfig = new DocumentBuilder()
    .setTitle('ALGOCEAN API')
    .setDescription('API Documentation')
    .setVersion('0.4.1')
    .addTag('ALGOCEAN')
    .addServer('')                   // .addServer('/')로 변경
    .build();
```

끝~