### PR TITLE
HOTFIX | 검색페이지가 사라진 버그 수정

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -4,6 +4,7 @@ import {
   MainPage,
   QuestionCreationPage,
   QuestionDetailPage,
+  QuestionSearchPage,
   LoginPage,
   SignupPage,
 } from './pages';
@@ -31,6 +32,7 @@ function App() {
               <Route path="/question/:id" element={<QuestionDetailPage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/signup" element={<SignupPage />} />
+              <Route path="/search" element={<QuestionSearchPage />} />
             </Routes>
             <Scroller />
           </Router>


### PR DESCRIPTION
### 버그 사항

질문 검색 페이지에 접근할 수 없는 버그가 있었습니다.

직전에 머지한 브랜치가 질문 검색 페이지 컴포넌트가 구현되기 전에 생성된 브랜치라
해당 컴포넌트를 불러오는 로직이 있으면 없는 컴포넌트를 불러와야 했고, 이로 인해 빌드 에러가 나는 상황이었습니다.

dev브랜치에 머지를 하기 위해선 반드시 build 테스트를 통과해야 했기 때문에,
임시적으로 질문 검색 페이지 컴포넌트와 관련된 로직을 제거했고, 이로 인해 질문 검색 페이지 사용이 불가해졌습니다.

<br/>

### 버그 해결 방식

App에서 질문 검색 페이지 컴포넌트를 추가했습니다.