### PR TITLE
refresh API jwt 응답 방식 수정

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -73,8 +73,16 @@ export class AuthController {
   }
 
   @Post('refresh')
-  async refresh(@Req() req) {
+  async refresh(@Req() req, @Res() res) {
     const { refreshToken } = req.body;
-    return await this.authService.refreshToken(refreshToken);
+    const { access_token, refresh_token } =
+      await this.authService.refreshToken(refreshToken);
+
+    res.cookie('refreshToken', refresh_token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+    });
+    res.send({ accessToken: access_token });
   }
 }

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -74,7 +74,7 @@ export class AuthController {
 
   @Post('refresh')
   async refresh(@Req() req, @Res() res) {
-    const { refreshToken } = req.body;
+    const refreshToken = req.cookies['refreshToken'];
     const { access_token, refresh_token } =
       await this.authService.refreshToken(refreshToken);
 


### PR DESCRIPTION
기존의 body에 refresh token을 넣어서 보내주던 방식에서
헤더에 보안설정 후에 보내는 방식으로 변경