### PR TITLE
프로필 API

### DIFF
--- a/BE/src/answers/answers.service.ts
+++ b/BE/src/answers/answers.service.ts
@@ -179,7 +179,14 @@ export class AnswersService {
       adoptedAnswerCount,
       adoptionRate,
       likes: likes._sum.LikeCount,
-      recentAnswers,
+      recentAnswers: recentAnswers.map((answer) => ({
+        id: answer.Id,
+        questionId: answer.Question.Id,
+        questionTitle: answer.Question.Title,
+        content: answer.Content,
+        isAdopted: answer.IsAdopted,
+        createdAt: answer.CreatedAt,
+      })),
     };
   }
 }

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -59,7 +59,11 @@ export class AuthService {
   async findOrCreateGithubUser(profile: Profile) {
     return this.prisma.user.upsert({
       where: { GithubId: profile.username },
-      create: { GithubId: profile.username, Nickname: profile.displayName },
+      create: {
+        GithubId: profile.username,
+        Nickname: profile.displayName,
+        UserId: '_' + profile.username,
+      },
       update: { Nickname: profile.displayName },
     });
   }

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -580,7 +580,16 @@ export class QuestionsService {
       answeredQuestionCount,
       adoptionRate,
       likes: likes._sum.LikeCount,
-      questions,
+      recentQuestions: questions.map((question) => ({
+        id: question.Id,
+        title: question.Title,
+        createdAt: question.CreatedAt,
+        tag: question.Tag,
+        programmingLanguage: question.ProgrammingLanguage,
+        isAdopted: question.IsAdopted,
+        viewCount: question.ViewCount,
+        likeCount: question.LikeCount,
+      })),
     };
   }
 }

--- a/BE/src/questions/questions.service.ts
+++ b/BE/src/questions/questions.service.ts
@@ -507,4 +507,80 @@ export class QuestionsService {
       throw new Error('Failed to find all by user id');
     }
   }
+
+  async getProfile(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { UserId: userId, DeletedAt: null },
+      select: { Id: true },
+    });
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const questionCount = await this.prisma.question.count({
+      where: {
+        UserId: user.Id,
+        DeletedAt: null,
+      },
+    });
+
+    const answeredQuestionCount = await this.prisma.question.count({
+      where: {
+        UserId: user.Id,
+        Answer: { some: {} },
+        DeletedAt: null,
+      },
+    });
+
+    const adoptedQuestionCount = await this.prisma.question.count({
+      where: {
+        UserId: user.Id,
+        IsAdopted: true,
+        DeletedAt: null,
+      },
+    });
+
+    // 답변 받은 질문 중 채택 완료한 질문의 퍼센트
+    const adoptionRate =
+      answeredQuestionCount === 0
+        ? 0
+        : Math.floor((adoptedQuestionCount / answeredQuestionCount) * 100);
+
+    const questions = await this.prisma.question.findMany({
+      where: {
+        UserId: user.Id,
+        DeletedAt: null,
+      },
+      select: {
+        Id: true,
+        Title: true,
+        CreatedAt: true,
+        Tag: true,
+        ProgrammingLanguage: true,
+        IsAdopted: true,
+        ViewCount: true,
+        LikeCount: true,
+      },
+      orderBy: { CreatedAt: 'desc' },
+      take: 3,
+    });
+
+    // 질문에 받은 좋아요의 합
+    const likes = await this.prisma.question.aggregate({
+      where: {
+        UserId: user.Id,
+        DeletedAt: null,
+      },
+      _sum: { LikeCount: true },
+    });
+
+    return {
+      questionCount,
+      answeredQuestionCount,
+      adoptionRate,
+      likes: likes._sum.LikeCount,
+      questions,
+    };
+  }
 }

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -114,7 +114,7 @@ export class UsersController {
       '본인 프로필을 조회합니다. 닉네임, 포인트, 등급, 프로필 사진 링크, 좋아요 합, 질문 갯수, 답변이 존재하는 질문 수, 질문 채택마감률, 최근 질문 최대 3개, 답변 갯수, 채택된 답변 갯수, 답변채택률, 최근 답변 최대 3개를 반환합니다.',
   })
   @UseGuards(AuthGuard('jwt'))
-  @Get('/myprofile')
+  @Get('/me')
   async getMyProfile(@Req() req) {
     const userId =
       req.user.provider === 'local' ? req.user.id : '_' + req.user.id;

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -6,12 +6,15 @@ import {
   HttpStatus,
   Param,
   Post,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AnswersService } from '../answers/answers.service';
 import { QuestionsService } from '../questions/questions.service';
+import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('users')
 @Controller('users')
@@ -96,12 +99,29 @@ export class UsersController {
   }
 
   @ApiOperation({
-    summary: '프로필 조회',
+    summary: '프로필 조회 (타인)',
     description:
       '프로필을 조회합니다. 닉네임, 포인트, 등급, 프로필 사진 링크, 좋아요 합, 질문 갯수, 답변이 존재하는 질문 수, 질문 채택마감률, 최근 질문 최대 3개, 답변 갯수, 채택된 답변 갯수, 답변채택률, 최근 답변 최대 3개를 반환합니다.',
   })
   @Get('/profile/:userId')
   async getProfile(@Param('userId') userId: string) {
+    return await this.profileInfo(userId);
+  }
+
+  @ApiOperation({
+    summary: '프로필 조회 (본인)',
+    description:
+      '본인 프로필을 조회합니다. 닉네임, 포인트, 등급, 프로필 사진 링크, 좋아요 합, 질문 갯수, 답변이 존재하는 질문 수, 질문 채택마감률, 최근 질문 최대 3개, 답변 갯수, 채택된 답변 갯수, 답변채택률, 최근 답변 최대 3개를 반환합니다.',
+  })
+  @UseGuards(AuthGuard('jwt'))
+  @Get('/myprofile')
+  async getMyProfile(@Req() req) {
+    const userId =
+      req.user.provider === 'local' ? req.user.id : '_' + req.user.id;
+    return await this.profileInfo(userId);
+  }
+
+  private async profileInfo(userId) {
     const usersPromise = this.usersService.getUserProfile(userId);
     const questionsPromise = this.questionsService.getProfile(userId);
     const answersPromise = this.answersService.getProfile(userId);

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -121,7 +121,7 @@ export class UsersController {
       questionCount: questions.questionCount,
       answeredQuestionCount: questions.answeredQuestionCount,
       questionAdoptionRate: questions.adoptionRate,
-      recentQuestions: questions.questions,
+      recentQuestions: questions.recentQuestions,
       answerCount: answers.answerCount,
       adoptedAnswerCount: answers.adoptedAnswerCount,
       answerAdoptionRate: answers.adoptionRate,

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -70,7 +70,7 @@ export class UsersService {
     return user;
   }
 
-  async getUserGrade(userId: string): Promise<string> {
+  async getUserGradeAndRanking(userId: string) {
     const user = await this.prisma.user.findUnique({
       where: { UserId: userId },
     });
@@ -105,6 +105,20 @@ export class UsersService {
       grade = 'Bronze';
     }
 
-    return grade;
+    return { grade, ranking: userPosition + 1 };
+  }
+
+  async getUserProfile(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { UserId: userId },
+      select: {
+        Nickname: true,
+        Points: true,
+        ProfileImage: true,
+      },
+    });
+    const { grade, ranking } = await this.getUserGradeAndRanking(userId);
+
+    return { ...user, grade, ranking };
   }
 }


### PR DESCRIPTION
일반 회원과 깃헙 회원이 공통으로 사용할 수 있는 식별자가 필요했습니다. 현재로선 primary key인 id값이 있습니다.
하지만 이 id값을 노출하길 원하지 않기 떄문에 userId 를 사용하기로 했습니다.
이를 위해 깃헙 회원은 userId에 본인의 '_'+username를 저장하게 했습니다. 이를 위해 일반 회원은 id의 첫자를 _로 지정할 수 없게 했습니다.

프로필 API는 이로서 userId: string 값으로 불러오는데에 더이상 문제가 없습니다.

userId 값을 client측애서 어떻게 알아내느냐가 조금 고민인데,
현재 상태로는 본인 userId만 클라이언트에서 accessToken을 해석해서 알아낼 수 있는 상태입니다. 
토큰 안의 provider값이 local이면 그냥 userId를 사용하면 되고 provider값이 github이면 userId값 앞에 _를 붙이면 됩니다.
이런 방식이 너무 복잡하기 떄문에 본인 프로필을 보는 API를 추가적으로 만들었습니다.

GET /api/users/me
userId는 사용자 아이디 string 값입니다. (본인 프로필 보는 용)
로그인돼있는 사용자만 사용가능
응답하는 값은 아래 API 와 동일

GET /api/users/profile/:userId
userId는 사용자 아이디 string 값입니다. (남의 프로필 보는 용)
제공하는 데이터는
```typescript
{
nickname: string,
points: number,
grade: string,
profileImage: string,
likeCount: number,
questionCount: number,
answeredQuestionCount: number,
questionAdoptionRate: number,
recentQuestions: {
  id: number,
  createdAt: Date,
  title: string,
  tag: string,
  programmingLanguage: string,
  isAdopted: boolean,
  viewCount: number,
  likeCount: number
}[],
answerCount: number,
adoptedAnswerCount: number,
answerAdoptionRateL number,
recentAnswers: {
  id: number,
  createdAt: Date,
  question: {Id: number, Title: string},
  content: string,
  isAdopted: boolean
}[]
}
```
이러합니다.