### PR TITLE
HOTFIX | VITE proxy가 정상적으로 작동하지 않던 버그 해결

### DIFF
--- a/FE/src/utils/network.ts
+++ b/FE/src/utils/network.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
-const { VITE_BASE_URL } = import.meta.env;
+const { VITE_BASE_URL, DEV } = import.meta.env;
+
+const baseURL = DEV ? '' : VITE_BASE_URL;
 
 export const client = axios.create({
-  baseURL: VITE_BASE_URL,
+  baseURL: baseURL,
   withCredentials: true,
 });


### PR DESCRIPTION
## 🐞 BUG 

### 문제 상황

VITE proxy를 잘못 적용하고 있던 버그.

proxy가 정상적으로 origin을 바꿔주지 못해
서버에서 정상적으로 cookie가 도착해도 브라우저가 cookie를 저장하지 않았다.

<br/>

### 문제 원인

proxy를 잘못 이해해서 사용하고 있었음.
proxy는 요청하는 API의 URL origin을 target URL origin으로 바꿔주고,
target의 응답 URL의 origin을 다시 원래의 URL origin으로 바꿔주는 역할임.

로컬과 cross origin 에러가 나지 않기 위해서는 로컬과 동일한 URL로 API를 쏘아야 함.
즉 로컬 주소가 `http://localhost`이면, `http://localhost/api/...`로 보내야만 cross origin이 나지 않음.

근데 지금 우리는 로컬 주소와 다른 `algocean.site/api/...`로 요청을 보내고 있었으니
proxy가 응답 URL origin을 로컬 주소가 아닌 `algocean.site/api/..`로 변환해서 전달하고 있었고,
이로 인해 cross origin 에러가 남.

### 해결 방법

axios의 baseURL을 개발 환경인지 배포 환경인지에 따라 다른 값을 가지도록 함.
- 개발 환경 : `localhost:5173`
- 배포 환경 : `algocean.site`

<br/>

## 논의할 사항

위의 해결 방법은 로컬에서 빌드한 환경에서는 적용이 되지 않음....
이건 어떻게 적용하지  🥲
