### PR TITLE
hotfix | 상세 질문 페이지 무한로딩

### DIFF
--- a/FE/src/api/questionService.ts
+++ b/FE/src/api/questionService.ts
@@ -17,7 +17,7 @@ export const getQuestionList = async (options: Options) => {
   }
 };
 
-export const getQuestionDetailContentData = async (questionId: number) => {
+export const getQuestionDetailContentData = async (questionId: string) => {
   try {
     const url = `/api/questions/${questionId}`;
     const { status, data } = await client.get(url);
@@ -25,17 +25,20 @@ export const getQuestionDetailContentData = async (questionId: number) => {
       throw new Error();
     }
     return data;
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
+    throw error;
   }
 };
 
-export const getQuestionAnswerListData = async (questionId: number) => {
+export const getQuestionAnswerListData = async (questionId: string) => {
   try {
     const url = `/api/answers/${questionId}`;
     const { data } = await client.get(url);
     const { answers } = data;
-    return answers;
+    return answers.map((answer: unknown) => {
+      return { cardData: answer };
+    });
   } catch (error: any) {
     if (error.response) {
       if (error.response.status === 404) {
@@ -48,11 +51,11 @@ export const getQuestionAnswerListData = async (questionId: number) => {
   }
 };
 
-export const postAnswer = async (content: string, questionId: number) => {
+export const postAnswer = async (content: string, questionId: string) => {
   try {
     const url = '/api/answers';
     const { status, data } = await client.post(url, {
-      questionId,
+      questionId: Number(questionId),
       content,
       videoLink: 'https://localhost.com',
     });

--- a/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
+++ b/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
@@ -10,8 +10,9 @@ import {
   Footer,
 } from './QuestionAnswerFormCard.styles';
 
-// ⚠️ 현재 로그인한 유저의 전역 이름을 가져오는 로직이 필요
-const GLOBAL_USER_NICKNAME = 'Snoopy';
+const GLOBAL_USER_NICKNAME = JSON.parse(
+  localStorage.getItem('userInfo')!,
+).nickname;
 
 const QuestionAnswerFormCard = ({
   handleCancel,

--- a/FE/src/pages/NotFoundPage/NotFoundPage.styles.ts
+++ b/FE/src/pages/NotFoundPage/NotFoundPage.styles.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  text-align: center;
+
+  div {
+    font-size: 8rem;
+    font-weight: 500;
+    color: ${({ theme }) => theme.color.mainColor.blueMain};
+    span {
+      font-size: 11rem;
+      font-weight: 900;
+      position: relative;
+      top: 1rem;
+    }
+  }
+  p {
+    margin-top: 3rem;
+    ${({ theme }) => theme.font.medium16}
+  }
+  small {
+    margin-top: 1rem;
+    ${({ theme }) => theme.font.light16}
+
+    span {
+      padding: 0 0.2rem;
+      font-weight: 700;
+    }
+  }
+`;

--- a/FE/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/FE/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Container } from './NotFoundPage.styles';
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+  const [count, setCount] = useState(4);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCount((count) => count - 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    if (count === 0) {
+      navigate('/');
+    }
+  });
+
+  return (
+    <Container>
+      <div>
+        웁스바리 <span>404</span> 링딩동
+      </div>
+      <p>존재하지 않는 페이지로 접근하셨네요</p>
+      <small>
+        <span>{count}</span>초 뒤 메인페이지로 이동할게요 🏃‍♀️💨
+      </small>
+    </Container>
+  );
+};
+
+export default NotFoundPage;

--- a/FE/src/pages/index.ts
+++ b/FE/src/pages/index.ts
@@ -5,6 +5,7 @@ import SignupPage from './SignupPage/SignupPage';
 import LoginPage from './LoginPage/LoginPage';
 import QuestionSearchPage from './QuestionSearchPage/QuestionSearchPage';
 import ProfilePage from './ProfilePage/ProfilePage';
+import NotFoundPage from './NotFoundPage/NotFoundPage';
 
 export {
   MainPage,
@@ -14,4 +15,5 @@ export {
   LoginPage,
   QuestionSearchPage,
   ProfilePage,
+  NotFoundPage,
 };

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -11,6 +11,7 @@ import {
   QuestionSearchPage,
   MainPage,
   ProfilePage,
+  NotFoundPage,
 } from '../pages';
 
 const unAuthorizedLoader = () => {
@@ -68,5 +69,13 @@ export const router = createBrowserRouter([
         loader: authorizedLoader,
       },
     ],
+  },
+  {
+    path: '*',
+    element: (
+      <ThemeProvider theme={theme}>
+        <NotFoundPage />
+      </ThemeProvider>
+    ),
   },
 ]);

--- a/FE/src/styles/reset.css
+++ b/FE/src/styles/reset.css
@@ -87,9 +87,9 @@ video {
   margin: 0;
   padding: 0;
   border: 0;
-  font-size: 100%;
-  font: inherit;
   vertical-align: baseline;
+  font: inherit;
+  line-height: 1;
 }
 /* HTML5 display-role reset for older browsers */
 article,

--- a/FE/src/utils/network.ts
+++ b/FE/src/utils/network.ts
@@ -5,5 +5,6 @@ const baseURL = DEV ? '' : VITE_BASE_URL;
 
 export const client = axios.create({
   baseURL: baseURL,
+  timeout: 5000,
   withCredentials: true,
 });


### PR DESCRIPTION
## 버그

### 버그 현상

질문 상세 페이지를 직접적으로 url을 입력해 접근하면
무한 로딩 상태인 버그가 있었습니다.

### 버그 원인

질문에 대한 Id값인 questionId를 useParams가 아닌 useLocation을 이용해서 가져오는 것이 문제였습니다.

useLocation은 라우팅할 때만 실행되는데,
직접적으로 url을 입력해 접근하면 라우팅으로 인식되지 않기에 useLocation이 실행되지 않았습니다.
이로인해 정상적인 questionId를 얻을 수 없어 무한 로딩 상태에 빠졌습니다.

### 해결 방식

useLocation이 아닌 useParams를 이용하여 questionId를 얻을 수 있도록 했습니다.

<br/>

## 추가 구현 사항

### 404 페이지 구현

없는 페이지로 접근시 404 화면을 보여주도록 했습니다.

<img width="600" alt="image" src="https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/bde42d69-7355-42ca-9095-cda31b4b9fd8">

### 없는 질문 Id로 접근 -> 404페이지로 이동

없는 질문 Id의 질문 상세 페이지로 이동시 404 페이지로 이동되도록 했습니다.