### PR TITLE
223 react query 적용

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -8,6 +8,8 @@
       "name": "algocean-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.12.2",
+        "@tanstack/react-query-devtools": "^5.13.3",
         "axios": "^1.6.2",
         "dotenv": "^16.3.1",
         "draft-js": "^0.11.7",
@@ -1550,6 +1552,55 @@
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.12.1.tgz",
+      "integrity": "sha512-WbZztNmKq0t6QjdNmHzezbi/uifYo9j6e2GLJkodsYaYUlzMbAp91RDyeHkIZrm7EfO4wa6Sm5sxJZm5SPlh6w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.13.3.tgz",
+      "integrity": "sha512-1acztPKZexvM9Ns2T0aq4rMVSDA3VGdB73KF7zT/KNVl6VfnBvs24wuIRVSPZKqyZznZTzT3/DzcpntYqg9hmw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.12.2.tgz",
+      "integrity": "sha512-BeWZu8zVFH20oRc+S/K9ADPgWjEzP/XQCGBNz5IbApUwPQAdwkQYbXODVL5AyAlWiSxhx+P2xlARPBApj2Yrog==",
+      "dependencies": {
+        "@tanstack/query-core": "5.12.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.13.3.tgz",
+      "integrity": "sha512-ct58CMRrcjANRWCQ6cxzSUtme2jlX5au63+ckhMONob8bIk5VRfUEi4R49AWNJFL5haTBKe0InC0AV4bWi75VQ==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.13.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.12.2",
+        "react": "^18.0.0"
+      }
     },
     "node_modules/@types/draft-js": {
       "version": "0.11.16",

--- a/FE/package.json
+++ b/FE/package.json
@@ -11,6 +11,8 @@
     "preview": "vite preview --open"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.12.2",
+    "@tanstack/react-query-devtools": "^5.13.3",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "draft-js": "^0.11.7",

--- a/FE/src/pages/QuestionSearchPage/QuestionSearchPage.tsx
+++ b/FE/src/pages/QuestionSearchPage/QuestionSearchPage.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ItemData } from '../../types/type';
 import { getQuestionList } from '../../api';
 import { Pagination, QuestionList } from '../../components';
 import { Main, Header, InnerDiv } from './QuestionSearchPage.style';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 
 const PAGINATION_SPLIT_NUMBER = 10;
 
@@ -14,19 +13,19 @@ const QuestionSearchPage = () => {
   const searchQuery = queryParams.get('query') as string;
   const page = Number(queryParams.get('page')) || 1;
 
-  const [questionListData, setQuestionListData] = useState<
-    ItemData[] | undefined
-  >(undefined);
-  const [wholePageCount, setwholePageCount] = useState<number | null>(null);
-
   const getQuestionListData = async () => {
-    const { questions, totalPage } = await getQuestionList({
-      page: page,
-      title: searchQuery,
-    });
-    setQuestionListData(questions);
-    setwholePageCount(totalPage);
+    return await getQuestionList({ page: page, title: searchQuery });
   };
+
+  const { data: questionListData } = useQuery({
+    queryKey: ['questionList', searchQuery, page],
+    queryFn: getQuestionListData,
+    staleTime: 10 * 1000,
+    gcTime: 30 * 1000,
+    placeholderData: keepPreviousData,
+  });
+
+  const wholePageCount = questionListData?.totalPage || 0;
 
   const handleCurrentPage = (page: number) => {
     navigate(
@@ -36,22 +35,22 @@ const QuestionSearchPage = () => {
     );
   };
 
-  useEffect(() => {
-    getQuestionListData();
-  }, [searchQuery, page]);
-
   return (
     <Main>
       <InnerDiv className="inner">
         <Header>검색 결과</Header>
-        <QuestionList questionListData={questionListData} />
-        {!!wholePageCount && (
-          <Pagination
-            wholePageCount={wholePageCount}
-            currentPage={page}
-            handleCurrentPage={handleCurrentPage}
-            splitNumber={PAGINATION_SPLIT_NUMBER}
-          />
+        {questionListData && (
+          <>
+            <QuestionList questionListData={questionListData.questions} />
+            {!!wholePageCount && (
+              <Pagination
+                wholePageCount={wholePageCount}
+                currentPage={page}
+                handleCurrentPage={handleCurrentPage}
+                splitNumber={PAGINATION_SPLIT_NUMBER}
+              />
+            )}
+          </>
         )}
       </InnerDiv>
     </Main>

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -12,6 +12,8 @@ import {
   MainPage,
   ProfilePage,
 } from '../pages';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const unAuthorizedLoader = () => {
   const isLogined = !!localStorage.getItem('userInfo');
@@ -23,17 +25,22 @@ const authorizedLoader = () => {
   return isLogined ? redirect('/') : null;
 };
 
+const queryClient = new QueryClient();
+
 export const router = createBrowserRouter([
   {
     path: '/',
     element: (
-      <AuthContextProvider>
-        <ThemeProvider theme={theme}>
-          <MainHeader />
-          <MainNav />
-          <Outlet />
-        </ThemeProvider>
-      </AuthContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={true} />
+        <AuthContextProvider>
+          <ThemeProvider theme={theme}>
+            <MainHeader />
+            <MainNav />
+            <Outlet />
+          </ThemeProvider>
+        </AuthContextProvider>
+      </QueryClientProvider>
     ),
     children: [
       {

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -15,6 +15,8 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
+const { DEV } = import.meta.env;
+
 const unAuthorizedLoader = () => {
   const isLogined = !!localStorage.getItem('userInfo');
   return !isLogined ? redirect('/') : null;
@@ -32,7 +34,7 @@ export const router = createBrowserRouter([
     path: '/',
     element: (
       <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools initialIsOpen={true} />
+        {DEV && <ReactQueryDevtools initialIsOpen={true} />}
         <AuthContextProvider>
           <ThemeProvider theme={theme}>
             <MainHeader />


### PR DESCRIPTION
Close #223 
<br/>

### React-Query 적용한 이유
- 클라이언트와 서버 데이터 분리 : 서버 데이터를 클라이언트 데이터와 분리함으로써 전체 애플리케이션의 데이터 관리를 더 효율적으로 구조화, 유지 보수 용이
- 데이터 캐싱 및 자동 재요청 : API 요청 결과를 캐싱하고, 필요할 때 자동으로 재요청한다. 성능 향상, 응답 시간 감소, 리소스 절약등의 이점이 있다.
- 비동기 데이터 처리 간소화 : 비동기 작업과 관련된 복잡한 로직을 간소화할 수 있다.

### React-Query-Devtools
애플리케이션에서 사용중인 React-Query 인스턴스의 상태와 정보를 시각적으로 확인할 수 있는 도구.
캐시된 쿼리, 뮤테이션, 캐시 상태 등에 대한 정보를 쉽게 모니터링하고 디버깅할 수 있다.
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/1e1da891-79a0-4409-8138-b4a80dc6c004)



###  구현한 기능

https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/955be489-2700-42bd-974b-235d743441b3

useQuery를 사용해서 데이터를 캐싱해서 staleTime 동안은 새로운 API 호출을 하지 않고, UI에는 캐시된 데이터를 사용하여 빠르게 렌더링합니다. 따라서 페이지를 3페이지에서 6페이지로 갔다가 다시 3페이지로 이동하였을 때 staleTime이 지나지 않았다면 API를 호출하지 않고 캐시된 데이터를 사용해서 UI를 구축하는 것을 영상에서 확인할 수 있습니다.



[👉 개발 배포 서버](https://web04-algocean-fe-dev.vercel.app/)

<br/>
<br/>

#### ✅ chore: react-query 라이브러리 추가

- 캐싱, 비동기 데이터 처리 간소화, 서버/클라이언트 데이터 분리를 위해 react-query 설치

#### ✅ feat: QueryClientProvider, ReactQueryDevtools 추가

- React Query 사용을 위한 초기 설정
- React Query 디버깅 및 모니터링 하는 도구 추가


#### ✅ feat: 메인 페이지, 질문 검색 페이지 useQuery 적용

- fetching한 데이터 useQuery로 상태 관리
- gcTime과 staleTime 부여함으로써 데이터 캐싱 및 자동 재요청

#### ✅ feat: 질문 등록 페이지 useMutation 적용

- 성공적인 뮤테이션 후 'questionList' 쿼리키를 가진 쿼리를 무효화
- 에러 핸들링을 useMutation 내부에서 처리

#### ✅ feat: ReactQueryDevtools DEV모드에만 적용

- ReactQueryDevtools이 유저에게 노출되지 않도록 수정




<br/>


## 개발일지
https://www.notion.so/React-Query-e38db83dd94544f5afcab9b8f33cfb1b

## 추가 논의할 사항
동영상 녹화를 하였는데, 저희 페이지네이션 데이터가 서버에서 부하 테스트를 위해 같은 제목의 내용만 도배 되어 있어서,
페이지 전환해도 티가 안나네요.. ㅋㅋ ㅠㅠ