### PR TITLE
HOTFIX | 화면 랜더링 버그 수정

### DIFF
--- a/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
+++ b/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
@@ -10,15 +10,14 @@ import {
   Footer,
 } from './QuestionAnswerFormCard.styles';
 
-const GLOBAL_USER_NICKNAME = JSON.parse(
-  localStorage.getItem('userInfo')!,
-).nickname;
-
 const QuestionAnswerFormCard = ({
   handleCancel,
   handleSubmit,
 }: QuestionAnswerFormCardProps) => {
   const [editorState, setEditorState] = useState(EditorState.createEmpty());
+  const GLOBAL_USER_NICKNAME = JSON.parse(
+    localStorage.getItem('userInfo')!,
+  ).nickname;
 
   const getEditorContent = () => {
     const editorContent = draftToHtml(


### PR DESCRIPTION
## 버그 현상 및 원인

로그인 하지 않은 상태로 알고션 접속시 화면이 랜더링 되지 않음.
로그인 전역 정보가 없는 상태에서 localstorage에서 유저 정보를 불러오려고 해서 생긴 버그

<br/>

## 해결

로그인 전역 정보를 로그인 한 상태에서만 불러오도록 수정

<br/>

## 비고

나는야 핫픽스 마스터