### PR TITLE
251 sweetalert2 적용

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -21,7 +21,8 @@
         "react-draft-wysiwyg": "^1.15.0",
         "react-hook-form": "^7.48.2",
         "react-router-dom": "^6.18.0",
-        "styled-components": "^6.1.1"
+        "styled-components": "^6.1.1",
+        "sweetalert2": "^11.10.1"
       },
       "devDependencies": {
         "@types/draft-js": "^0.11.16",
@@ -5462,6 +5463,15 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.1.tgz",
+      "integrity": "sha512-qu145oBuFfjYr5yZW9OSdG6YmRxDf8CnkgT/sXMfrXGe+asFy2imC2vlaLQ/L/naZ/JZna1MPAY56G4qYM0VUQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
     },
     "node_modules/synckit": {
       "version": "0.8.5",

--- a/FE/package.json
+++ b/FE/package.json
@@ -24,7 +24,8 @@
     "react-draft-wysiwyg": "^1.15.0",
     "react-hook-form": "^7.48.2",
     "react-router-dom": "^6.18.0",
-    "styled-components": "^6.1.1"
+    "styled-components": "^6.1.1",
+    "sweetalert2": "^11.10.1"
   },
   "devDependencies": {
     "@types/draft-js": "^0.11.16",

--- a/FE/src/components/MainHeader/MainHeader.tsx
+++ b/FE/src/components/MainHeader/MainHeader.tsx
@@ -38,6 +38,9 @@ function SearchBar() {
         icon: 'warning',
         title: '검색어를 입력해주세요.',
         confirmButtonText: '확인',
+        toast: true,
+        timer: 1000,
+        showConfirmButton: false,
       });
 
       return;

--- a/FE/src/components/MainHeader/MainHeader.tsx
+++ b/FE/src/components/MainHeader/MainHeader.tsx
@@ -10,6 +10,7 @@ import {
 } from './MainHeader.styles';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import Swal from 'sweetalert2';
 
 const PAGE_TITLE = 'ALGOCEAN';
 
@@ -33,7 +34,13 @@ function SearchBar() {
     e.preventDefault();
     // 검색어가 비어있으면 navigate를 하지 않음
     if (!searchValue.trim()) {
-      return alert('검색어를 입력해주세요.');
+      Swal.fire({
+        icon: 'warning',
+        title: '검색어를 입력해주세요.',
+        confirmButtonText: '확인',
+      });
+
+      return;
     }
     navigate(`/search?query=${encodeURIComponent(searchValue)}`);
   };

--- a/FE/src/components/MainNav/MainNav.tsx
+++ b/FE/src/components/MainNav/MainNav.tsx
@@ -4,6 +4,7 @@ import { AuthContext } from '../../contexts/AuthContexts';
 import { postDraftQuestionAPI } from '../../api';
 import writeIcon from '/icons/write.svg';
 import * as S from './MainNav.styles';
+import Swal from 'sweetalert2';
 
 const getCurrentNavItem = () => {
   const { pathname } = window.location;
@@ -20,8 +21,20 @@ export function MainNav() {
     const isLogined = localStorage.getItem('userInfo');
     const accessToken = getAccessToken();
     if (!isLogined || !accessToken) {
-      alert('로그인 후 질문 작성이 가능합니다 😉');
-      return navigate('/login');
+      Swal.fire({
+        width: 600,
+        icon: 'question',
+        title: '로그인 후 질문 작성이 가능합니다 😉',
+        text: '로그인 페이지로 이동하시겠습니까?',
+        showCancelButton: true,
+        cancelButtonText: '취소',
+        confirmButtonText: '확인',
+      }).then((result) => {
+        if (result.isConfirmed) {
+          return navigate('/login');
+        }
+      });
+      return;
     }
 
     // 여기에서 POST 요청을 수행

--- a/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
+++ b/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
@@ -43,6 +43,9 @@ const QuestionAnswerFormCard = ({
         icon: 'info',
         title: '답변을 입력해 주세요.',
         confirmButtonText: '확인',
+        toast: true,
+        timer: 1000,
+        showConfirmButton: false,
       });
     }
     handleSubmit(editorContent);

--- a/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
+++ b/FE/src/components/QuestionAnswerFormCard/QuestionAnswerFormCard.tsx
@@ -9,6 +9,7 @@ import {
   Header,
   Footer,
 } from './QuestionAnswerFormCard.styles';
+import Swal from 'sweetalert2';
 
 const QuestionAnswerFormCard = ({
   handleCancel,
@@ -35,11 +36,14 @@ const QuestionAnswerFormCard = ({
   const onCancelButtonClick = () => {
     handleCancel();
   };
-
   const onSubmitButtonClick = () => {
     const editorContent = getEditorContent();
     if (isEditorContentEmpty(editorContent)) {
-      return alert('답변을 입력해 주세요');
+      return Swal.fire({
+        icon: 'info',
+        title: '답변을 입력해 주세요.',
+        confirmButtonText: '확인',
+      });
     }
     handleSubmit(editorContent);
   };

--- a/FE/src/components/QuestionProfile/QuestionProfile.tsx
+++ b/FE/src/components/QuestionProfile/QuestionProfile.tsx
@@ -8,6 +8,7 @@ import {
   Signup,
 } from './QuestionProfile.styles';
 import { AuthContext } from '../../contexts/AuthContexts';
+import Swal from 'sweetalert2';
 
 export function Login() {
   const navigate = useNavigate();
@@ -35,7 +36,13 @@ function AuthorizedProfile({
   const onLogoutClick = () => {
     localStorage.removeItem('userInfo');
     deleteAccessToken();
-    alert('로그아웃이 완료되었습니다');
+    Swal.fire({
+      icon: 'success',
+      title: '로그아웃이 완료되었습니다',
+      showConfirmButton: false,
+      toast: true,
+      timer: 1000,
+    });
     handleIsLogined(false);
   };
 

--- a/FE/src/pages/LoginPage/LoginPage.tsx
+++ b/FE/src/pages/LoginPage/LoginPage.tsx
@@ -5,6 +5,7 @@ import { getWhoAmI, postLogin } from '../../api';
 import { LoginFetchData as FormData } from 'src/types/type';
 import { Container, Inner, Form } from './LoginPage.styles';
 import { AuthContext } from '../../contexts/AuthContexts';
+import Swal from 'sweetalert2';
 
 interface LoginFormProps {
   handleLoginSubmit: (data: FormData) => void;
@@ -62,9 +63,12 @@ const LoginPage = () => {
     const data = await postLogin(fetchData);
 
     if (!data) {
-      return alert(
-        '로그인에 실패했습니다. 아이디 혹은 비밀번호를 확인해주세요',
-      );
+      return Swal.fire({
+        icon: 'error',
+        title: '로그인 실패',
+        text: '아이디 혹은 비밀번호를 확인해주세요',
+        confirmButtonText: '확인',
+      });
     }
 
     const { accessToken } = data;

--- a/FE/src/pages/LoginPage/LoginPage.tsx
+++ b/FE/src/pages/LoginPage/LoginPage.tsx
@@ -77,7 +77,14 @@ const LoginPage = () => {
     const { Nickname: nickname, Points: points } = await getWhoAmI();
     localStorage.setItem('userInfo', JSON.stringify({ nickname, points }));
 
-    alert('성공적으로 로그인이 완료되었습니다');
+    Swal.fire({
+      icon: 'success',
+      title: '로그인이 완료되었습니다',
+      showConfirmButton: false,
+      toast: true,
+      timer: 1000,
+    });
+
     navigate(-1);
   };
 

--- a/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
+++ b/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
@@ -17,6 +17,7 @@ import draftToHtml from 'draftjs-to-html';
 import { createQuestionAPI, putDraftQuestionAPI } from '../../api';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Swal from 'sweetalert2';
 
 const POLLING_INTERVAL = 20000;
 const TAG_LIST = ['baekjoon', 'programmers', 'leetcode', 'etc'];
@@ -48,7 +49,11 @@ const QuestionCreationPage = () => {
     () => {},
     () => {
       putDraftQuestion();
-      alert('임시글이 등록되었습니다.');
+      Swal.fire({
+        icon: 'success',
+        title: '글이 임시 등록되었습니다.',
+        confirmButtonText: '확인',
+      });
     },
     () => {
       navigate('/');
@@ -130,9 +135,16 @@ const QuestionCreationPage = () => {
     }
 
     if (errorMessages.length > 0) {
-      alert(errorMessages.join('\n'));
+      const errorMessageHTML = errorMessages.join('<br>');
+      Swal.fire({
+        icon: 'error',
+        title: '질문 등록 실패',
+        html: errorMessageHTML,
+        confirmButtonText: '확인',
+      });
       return false;
     }
+
     return true;
   };
 

--- a/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
+++ b/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
@@ -152,6 +152,11 @@ const QuestionCreationPage = () => {
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (checkValidation()) {
+      Swal.fire({
+        icon: 'success',
+        title: '글이 등록되었습니다.',
+        confirmButtonText: '확인',
+      });
       createQuestion();
     }
   };

--- a/FE/src/pages/QuestionDetailPage/QuestionDetailPage.tsx
+++ b/FE/src/pages/QuestionDetailPage/QuestionDetailPage.tsx
@@ -19,6 +19,7 @@ import {
 
 import { Container, NoAnswer } from './QuestionDetailPage.styles';
 import { AuthContext } from '../../contexts/AuthContexts';
+import Swal from 'sweetalert2';
 
 const QuestionDetailPage = () => {
   const { id: questionId } = useParams();
@@ -35,7 +36,11 @@ const QuestionDetailPage = () => {
 
   const submitAnswer = async (content: string) => {
     if (!getAccessToken()) {
-      alert('로그인 후 답변 가능합니다');
+      Swal.fire({
+        icon: 'error',
+        title: '로그인후 답변가능합니다',
+        confirmButtonText: '확인',
+      });
       return navigate('/login');
     }
 

--- a/FE/src/pages/SignupPage/SignupPage.tsx
+++ b/FE/src/pages/SignupPage/SignupPage.tsx
@@ -4,6 +4,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { getUserIdVerified, postSignup } from '../../api';
 import { SignupFetchData as FetchData } from 'src/types/type';
 import { Container, Inner, Form } from './SignupPage.styles';
+import Swal from 'sweetalert2';
 
 interface SignupFormProps {
   handleSignupSubmit: (data: FetchData) => void;
@@ -115,7 +116,12 @@ const SignupPage = () => {
     const isSuccess = await postSignup(fetchData);
 
     if (!isSuccess) {
-      return alert('회원 가입에 실패했습니다. 다시 시도해 주세요');
+      return Swal.fire({
+        icon: 'error',
+        title: '회원가입 실패',
+        text: '다시 시도해 주세요.',
+        confirmButtonText: '확인',
+      });
     }
     alert('성공적으로 회원 가입이 완료되었습니다');
     navigate('/');

--- a/FE/src/pages/SignupPage/SignupPage.tsx
+++ b/FE/src/pages/SignupPage/SignupPage.tsx
@@ -123,7 +123,13 @@ const SignupPage = () => {
         confirmButtonText: '확인',
       });
     }
-    alert('성공적으로 회원 가입이 완료되었습니다');
+    Swal.fire({
+      icon: 'success',
+      title: '회원가입에 성공하였습니다.',
+      showConfirmButton: false,
+      toast: true,
+      timer: 2000,
+    });
     navigate('/');
   };
 

--- a/FE/src/styles/reset.css
+++ b/FE/src/styles/reset.css
@@ -3,10 +3,16 @@
    License: none (public domain)
 */
 
+span,
+div {
+  padding: 0;
+  vertical-align: baseline;
+  font: inherit;
+  line-height: 1;
+}
+
 html,
 body,
-div,
-span,
 applet,
 object,
 iframe,


### PR DESCRIPTION
Close #251  
<br/>

###  구현한 기능

sweetalert2 적용

### 도입한 이유
기존에 별 다른 모달, 토스트 창을 만들어 두지 않고 js에서 제공하는 alert 함수를 사용하였다.
UI, UX를 고려했을 때 alert창을 계속 가져가는 것은 적합하지 않다고 판단하였고
 커스터마이징 할 수 있는 모달창을 제공하는 라이브러리인 sweetalert2를 적용하였다. 

[👉 개발 배포 서버](https://web04-algocean-fe-dev.vercel.app/)

### 캡처한거라 테두리 부분이 약간 이상할 수 있습니다.
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/9b9ef724-4e67-4de1-8ffa-ed51e3114085)
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/27d31967-3a2f-4886-9e2d-e7e433b03335)
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/ab237cea-8568-4ed8-8c7d-c8fcc9c98839)
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/8ecaeef3-edc1-4f93-84ff-f33b69a64a17)
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/9dfe13a2-6ac6-4b48-8407-a706576a3942)

![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/76561b3a-b0af-4716-af94-dcf64528dce1)
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/3b2c0641-b3a2-4cd2-9009-859a39b7d7a8)


<br/>
<br/>

#### ✅ chore: sweetalert2 라이브러리 설치

- sweetalert2 라이브러리 설치

#### ✅ design: reset.css에 span, div 수정

- span, div로 주는 margin과 border 속성 제외

#### ✅ feat: sweetalert2 모달창 추가

- 기존 alert 대신 sweetalert2 모달창으로 변경

#### ✅ feat: sweetalert2 토스트 추가

- 기존 alert 대신 sweetalert2 토스트로 변경

<br/>

### 논의할 거리
reset.css에 있는 div와 span 태그에 있는 border와 margin 속성이 sweetalert2 라이브러리에서 제공하는 아이콘의 border와 margin을 건드려서 해당 css를 제외하였습니다. 
만약에 div와 span 태그의 margin: 0 과 border: 0을 살리는 게 낫다고 판단하시면 reset.css를 롤백하고 해당 아이콘에서 reset.css의 속성을 무시하는 방향으로 변경하겠습니다.