### PR TITLE
276 임시 저장 불러오기 기능 구현

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.3.1",
         "draft-js": "^0.11.7",
         "draftjs-to-html": "^0.9.1",
+        "html-to-draftjs": "^1.5.0",
         "lodash": "^4.17.21",
         "prettier": "^3.1.0",
         "react": "^18.2.0",
@@ -29,6 +30,7 @@
       "devDependencies": {
         "@types/draft-js": "^0.11.16",
         "@types/draftjs-to-html": "^0.8.4",
+        "@types/html-to-draftjs": "^1.4.3",
         "@types/lodash": "^4.14.202",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -1638,6 +1640,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
+    },
+    "node_modules/@types/html-to-draftjs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/html-to-draftjs/-/html-to-draftjs-1.4.3.tgz",
+      "integrity": "sha512-8TAgtzFA/sfwjGNXJ7Zod5tgnqsfJFQZYB8Nmu9GIoF7AVSwRm2quF1Ve09dHgHxSVsTSSy2diZSVdeSvTe7vg==",
+      "dev": true,
+      "dependencies": {
+        "@types/draft-js": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/FE/package.json
+++ b/FE/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^16.3.1",
     "draft-js": "^0.11.7",
     "draftjs-to-html": "^0.9.1",
+    "html-to-draftjs": "^1.5.0",
     "lodash": "^4.17.21",
     "prettier": "^3.1.0",
     "react": "^18.2.0",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@types/draft-js": "^0.11.16",
     "@types/draftjs-to-html": "^0.8.4",
+    "@types/html-to-draftjs": "^1.4.3",
     "@types/lodash": "^4.14.202",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/FE/src/api/index.ts
+++ b/FE/src/api/index.ts
@@ -16,6 +16,7 @@ export {
   createQuestionAPI,
   postDraftQuestionAPI,
   putDraftQuestionAPI,
+  getDraftQuestionAPI,
 } from './questionService';
 
 export { getRankingListData } from './ranking';

--- a/FE/src/api/questionService.ts
+++ b/FE/src/api/questionService.ts
@@ -72,6 +72,26 @@ export const createQuestionAPI = async (data: QuestionData) => {
   return await client.post('/api/questions', data);
 };
 
+export const getDraftQuestionAPI = async () => {
+  try {
+    const res = await client.get('/api/questions/drafts');
+    return res.data;
+  } catch (error: any) {
+    if (error.response) {
+      // 서버 응답이 있는 경우 (오류 상태 코드 처리)
+      if (error.response.status === 500) {
+        console.error('Internal Server Error:', error.response.data);
+      } else {
+        console.error('Server Error:', error.response.data);
+      }
+    } else {
+      // 서버 응답이 없는 경우 (네트워크 오류 등)
+      console.error('Error creating question:', error.message);
+    }
+    throw error;
+  }
+};
+
 export const postDraftQuestionAPI = async () => {
   try {
     const res = await client.post('/api/questions/drafts');

--- a/FE/src/components/DocumentEditor/DocumentEditor.tsx
+++ b/FE/src/components/DocumentEditor/DocumentEditor.tsx
@@ -12,7 +12,7 @@ interface EditorProps {
   editorState: EditorState;
   setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
   handleFocusCallback?: () => QuestionData;
-  draftContent: string | undefined;
+  draftContent?: string | undefined;
 }
 
 const POLLING_INTERVAL = 30000;

--- a/FE/src/components/DocumentEditor/DocumentEditor.tsx
+++ b/FE/src/components/DocumentEditor/DocumentEditor.tsx
@@ -50,6 +50,7 @@ const DocumentEditor = ({
 
   // draft 반영
   useDidMountEffect(() => {
+    if (!draftContent) return;
     const blocksFromHTML = htmlToDraft(draftContent as string);
     if (!blocksFromHTML) return;
     const { contentBlocks, entityMap } = blocksFromHTML;

--- a/FE/src/pages/QuestionCreationPage/QuestionCreationPage.style.ts
+++ b/FE/src/pages/QuestionCreationPage/QuestionCreationPage.style.ts
@@ -101,7 +101,7 @@ export const TagButton = styled.button<TagButtonProps>`
       : '1px solid transparent'};
   border-radius: 1rem;
   background-color: ${({ $isactive, theme }) =>
-    $isactive ? theme.color.grayscale.white : theme.color.grayscale[50]};
+    $isactive ? theme.color.mainColor.blueOutline : theme.color.grayscale[50]};
   color: ${({ $isactive, theme }) =>
     $isactive ? theme.color.grayscale.black : theme.color.grayscale[200]};
 `;

--- a/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
+++ b/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { DocumentEditor } from '../../components';
 import {
   Main,

--- a/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
+++ b/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
@@ -270,7 +270,7 @@ const QuestionCreationPage = () => {
             <Label>제목</Label>
             <Input
               type="text"
-              value={formData.title}
+              value={formData.title || ''}
               placeholder="내용을 입력해 주세요."
               onFocus={handleFocus}
               onBlur={handleBlur}
@@ -302,7 +302,7 @@ const QuestionCreationPage = () => {
             <Label>문제 원본 링크</Label>
             <Input
               type="text"
-              value={formData.originalLink}
+              value={formData.originalLink || ''}
               placeholder="내용을 입력해 주세요."
               onChange={(e) =>
                 handleInputChange('originalLink', e.target.value)

--- a/FE/src/types/type.d.ts
+++ b/FE/src/types/type.d.ts
@@ -134,3 +134,11 @@ export interface RankingItemProps {
     grade: string;
   };
 }
+
+interface DraftData {
+  title: string;
+  content: string;
+  tag: string;
+  programmingLanguage: string;
+  originalLink: string;
+}


### PR DESCRIPTION
Close #276 
<br/>

###  구현한 기능

#### 임시 저장글 불러오기 기능 구현

[👉 개발 배포 서버](https://web04-algocean-fe-dev.vercel.app/)

### 임시글 불러오기

![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/e82d23ee-eeae-4fe6-a910-a32382adff90)

### 디자인 변경

![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/d1f71b6f-c851-40a3-9b7b-b390aadb1d5c)



<br/>

#### ✅ chore: html-to-draftjs 추가

- html 형식 string을 문서에디터에 넣을 수 있게 해주는 라이브러리 추가


#### ✅ feat: draft 받아오는 api 추가

- getDraftQuestionAPI 추가


#### ✅ design: 선택된 태그 색상 변경

- 기존 색상이 눈에 띄지 않아서 수정

#### ✅ feat: 질문 등록 페이지 draft 반영

- useQuery로 draftData 반환
- draftData를 formData에 반영


#### ✅ feat: 문서에디터 draft 반영

- draftContent props 추가
- draftContent를 여러 함수를 거쳐 editorState에 반영

<br/>
