### PR TITLE
288-프로필-페이지-rank-반영

### DIFF
--- a/FE/src/components/ProfileInfo/ProfileInfo.tsx
+++ b/FE/src/components/ProfileInfo/ProfileInfo.tsx
@@ -18,6 +18,7 @@ interface ProfileInfoProps {
   userAdoptedAnswerCount: number;
   userAnswerCount: number;
   userQuestionCount: number;
+  userRanking: number;
 }
 
 export function ProfileInfo({
@@ -27,10 +28,10 @@ export function ProfileInfo({
   userAdoptedAnswerCount,
   userAnswerCount,
   userQuestionCount,
+  userRanking,
 }: ProfileInfoProps) {
-  // user/me api에 등수는 아직 안 내려와서 mock data 추가.
   const data = [
-    { topic: '등수', content: '2등' },
+    { topic: '등수', content: `${userRanking}등` },
     { topic: '포인트', content: userPoint },
     { topic: '전체 질문', content: `${userQuestionCount}건` },
     { topic: '전체 답변', content: `${userAnswerCount}건` },

--- a/FE/src/pages/ProfilePage/ProfilePage.tsx
+++ b/FE/src/pages/ProfilePage/ProfilePage.tsx
@@ -34,6 +34,7 @@ export default function ProfilePage() {
               userAdoptedAnswerCount={userProfileData.adoptedAnswerCount}
               userAnswerCount={userProfileData.answerCount}
               userQuestionCount={userProfileData.questionCount}
+              userRanking={userProfileData.ranking}
             />
             <ProfileQuestionList
               userQuestionList={userProfileData.recentQuestions}


### PR DESCRIPTION
Close #288 
<br/>

###  구현한 기능

#### 프로필 페이지 rank 반영

[👉 개발 배포 서버](https://web04-algocean-fe-dev.vercel.app/)

![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/5f896fb7-5882-4b38-93b3-ff3dfc50018f)


<br/>
<br/>

#### ✅ feat: 프로필 페이지 ranking 추가

- 추가된 rank 정보 반영

<br/>
