### PR TITLE
로그인 도중 에러가 날 시 로그인을 취소하는 로직 추가

### DIFF
--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -116,8 +116,7 @@ export class UsersController {
   @UseGuards(AuthGuard('jwt'))
   @Get('/me')
   async getMyProfile(@Req() req) {
-    const userId =
-      req.user.provider === 'local' ? req.user.UserId : '_' + req.user.UserId;
+    const userId = req.user.UserId;
     return await this.profileInfo(userId);
   }
 

--- a/FE/src/api/auth.ts
+++ b/FE/src/api/auth.ts
@@ -62,6 +62,7 @@ export const getWhoAmI = async () => {
     return { userId, nickname, points };
   } catch (error: any) {
     console.error(error);
+    throw error();
   }
 };
 

--- a/FE/src/pages/LoginPage/LoginPage.tsx
+++ b/FE/src/pages/LoginPage/LoginPage.tsx
@@ -90,18 +90,30 @@ const LoginPage = () => {
     const { accessToken } = data;
     setAccessToken(accessToken);
 
-    const userInfo = await getWhoAmI();
-    localStorage.setItem('userInfo', JSON.stringify(userInfo));
+    try {
+      const userInfo = await getWhoAmI();
+      localStorage.setItem('userInfo', JSON.stringify(userInfo));
 
-    Swal.fire({
-      icon: 'success',
-      title: '로그인이 완료되었습니다',
-      showConfirmButton: false,
-      toast: true,
-      timer: 1000,
-    });
+      Swal.fire({
+        icon: 'success',
+        title: '로그인이 완료되었습니다',
+        showConfirmButton: false,
+        toast: true,
+        timer: 1000,
+      });
 
-    navigate(-1);
+      navigate(-1);
+    } catch (error) {
+      Swal.fire({
+        icon: 'error',
+        title: '로그인 실패',
+        text: '다시 시도해주세요',
+        showConfirmButton: false,
+        toast: true,
+        timer: 1000,
+      });
+      navigate('/login');
+    }
   };
 
   return (


### PR DESCRIPTION
로그인 도중 에러가 날 경우 에러를 표출하도록 핸들링했습니다.
try catch를 통해 에러 발생시 강제로 /login 페이지로 라우팅합니다.

현재 확인된 에러 사항
- 서버에서 400 상태값이 내려올 때
- 서버에서 500 상태값이 내려올 때