### PR TITLE
SEO 관련 - 캐노니컬 태그 추가

### DIFF
--- a/FE/src/metas/metas.tsx
+++ b/FE/src/metas/metas.tsx
@@ -33,6 +33,7 @@ export const MainPageMetas = () => {
         content="알고리즘 관련 질문을 올리고 답변할 수 있는 커뮤니티"
       />
       <meta name="keywords" content="알고션, ALGOCEAN" />
+      <link rel="canonical" href="https://algocean.site" />
     </Helmet>
   );
 };


### PR DESCRIPTION
### 문제 상황

"ALGOCEAN" 검색시 나타나는 페이지인 쿠버네티스 서버가 최신 버전이 아니라서
사용자가 오래된 버전의 서비스만 이용하게 되는 문제가 발생했습니다.

<br/>

현재 배포된 알고션 사이트는 2개가 있습니다.

- https://algocean.site (젠킨스 ver.)
- https://www.algocean.site (쿠버네티스 ver.)

<br/>

구글 서치 콘솔이 두 사이트가 비슷한 URL에 비슷한 내용이라서
**두 사이트를 동일한 내용의 중복된 페이지로 인식하고 둘 중 메인 사이트를 쿠버네티스 서버로 지정**했더군요.

그래서 **두 사이트 관련된 키워드를 사용한 검색은 모조리 쿠버네티스 서버만 보여줍니다.**
(젠킨스 서버는 url 직접 입력하는거 아니면 절대 안나옴. 으악 😱 )

<img width="500" alt="image" src="https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/97934878/24c113bb-38ea-4772-9a72-c7519e2d577f" />


<br/><br/>

쿠버네티스 서버는 자동 배포가 안되어 종종 예전 버전의 서비스를 제공하게 되는데
이런 경우 검색으로 유입된 사용자가 오래된 서비스만 사용하게 된다는 문제로 이어졌습니다.

<br/>

### 문제 해결

알고션 메인페이지의 헤드에 캐노니컬 태그를 추가하여 
구글 검색 엔진이 젠킨스 서버와 쿠버네티스 서버 모두 젠킨스 서버를 메인으로 인식하도록 해주었습니다.

#### 캐노니컬 태그?

캐노니컬 태그는 구글 서치 엔진이 비슷한 URL의 동일한 내용이 중복되는 2개의 사이트에 대해
개발자가 원하는 페이지를 메인으로 인식하도록 해줍니다.

캐노니컬 태그의 더 정확한 역할에 대해 궁금하다면
[rel="canonical" 및 다른 메서드로 표준 URL을 지정하는 방법](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?sjid=7408063087267517522-AP&visit_id=638380490018953898-770040574&rd=1&hl=ko)을 참고해주시면 됩니다.

<br/>

### 추가 논의 사항

#### 왜?

두 페이지 중 왜 구글 서치 콘솔이 쿠버네티스 서버를 메인으로 했는지는 모르겠습니다.

서치 콘솔에 algocean.site가 아닌 www.algocean.site로 등록했었나?도 고려해 봤는데
등록 시기가 쿠버네티스 배포 전이라 그건 아닌 것 같습니다.

도통 이유를 모르겠네요 🥲

#### 사실

이 문제는 쿠버네티스도 항상 최신 버전을 배포하도록 하면 해결됩니다...ㅎㅎ
혹시 쿠버네티스 배포 자동화......크흠
@seungy0 

<br/>