### PR TITLE
295 로딩 상태를 선언적으로 관리

### DIFF
--- a/FE/src/api/questionService.ts
+++ b/FE/src/api/questionService.ts
@@ -1,4 +1,8 @@
-import { GetQuestionListOptions as Options, QuestionData } from '../types/type';
+import {
+  GetQuestionListOptions as Options,
+  QuestionData,
+  QuestionAnswerData,
+} from '../types/type';
 import { client } from '../utils/network';
 
 export const getQuestionList = async (options: Options) => {
@@ -35,18 +39,12 @@ export const getQuestionAnswerListData = async (questionId: string) => {
   try {
     const url = `/api/answers/${questionId}`;
     const { data } = await client.get(url);
-    const { answers } = data;
-    return answers.map((answer: unknown) => {
-      return { cardData: answer };
-    });
+    if (data === '') return null;
+
+    const answers: QuestionAnswerData[] = data.answers;
+    return answers;
   } catch (error: any) {
-    if (error.response) {
-      if (error.response.status === 404) {
-        return null;
-      }
-    } else {
-      console.error('Error from get answer list data:', error.message);
-    }
+    console.error('Error from get answer list data:', error.message);
     throw error;
   }
 };

--- a/FE/src/pages/MainPage/MainPage.tsx
+++ b/FE/src/pages/MainPage/MainPage.tsx
@@ -17,12 +17,26 @@ import {
 import { MainPageMetas } from '../../metas/metas';
 
 const PAGINATION_SPLIT_NUMBER = 10;
+const UNIQUE_QUESTION_INITIAL_DATA = [
+  {
+    type: 'hot',
+    title: '',
+    id: 0,
+  },
+  {
+    type: 'today',
+    title: '',
+    id: 0,
+  },
+  {
+    type: 'random',
+    title: '',
+    id: 0,
+  },
+];
 
-export default function MainPage() {
+const MainContent = ({ page }: { page: number }) => {
   const navigate = useNavigate();
-  const location = useLocation();
-  const queryParams = new URLSearchParams(location.search);
-  const page = Number(queryParams.get('page')) || 1;
 
   const getQuestionListData = async () => {
     return await getQuestionList({ page: page });
@@ -33,6 +47,36 @@ export default function MainPage() {
     queryFn: getQuestionListData,
     placeholderData: keepPreviousData,
   });
+
+  const wholePageCount = questionListData?.totalPage || 0;
+
+  const handleCurrentPage = (page: number) => {
+    navigate(`/?page=${encodeURIComponent(page)}`);
+  };
+
+  return (
+    <Main>
+      {questionListData && (
+        <>
+          <QuestionList questionListData={questionListData.questions} />
+          {!!wholePageCount && (
+            <Pagination
+              wholePageCount={wholePageCount}
+              currentPage={page}
+              handleCurrentPage={handleCurrentPage}
+              splitNumber={PAGINATION_SPLIT_NUMBER}
+            />
+          )}
+        </>
+      )}
+    </Main>
+  );
+};
+
+export default function MainPage() {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const page = Number(queryParams.get('page')) || 1;
 
   const getNavQuestionData = async () => {
     try {
@@ -70,15 +114,10 @@ export default function MainPage() {
   const { data: navQuestionData } = useQuery({
     queryKey: ['navQuestion'],
     queryFn: getNavQuestionData,
-    staleTime: 30 * 1000,
+    staleTime: 0,
+    initialData: () => UNIQUE_QUESTION_INITIAL_DATA,
     placeholderData: keepPreviousData,
   });
-
-  const wholePageCount = questionListData?.totalPage || 0;
-
-  const handleCurrentPage = (page: number) => {
-    navigate(`/?page=${encodeURIComponent(page)}`);
-  };
 
   return (
     <Container>
@@ -88,21 +127,7 @@ export default function MainPage() {
           <UniqueQuestions questions={navQuestionData as Question[]} />
           <QuestionProfile />
         </HeroBanner>
-        <Main>
-          {questionListData && (
-            <>
-              <QuestionList questionListData={questionListData.questions} />
-              {!!wholePageCount && (
-                <Pagination
-                  wholePageCount={wholePageCount}
-                  currentPage={page}
-                  handleCurrentPage={handleCurrentPage}
-                  splitNumber={PAGINATION_SPLIT_NUMBER}
-                />
-              )}
-            </>
-          )}
-        </Main>
+        <MainContent page={page} />
       </Inner>
     </Container>
   );

--- a/FE/src/pages/MainPage/MainPage.tsx
+++ b/FE/src/pages/MainPage/MainPage.tsx
@@ -31,8 +31,6 @@ export default function MainPage() {
   const { data: questionListData } = useQuery({
     queryKey: ['questionList', page],
     queryFn: getQuestionListData,
-    staleTime: 10 * 1000,
-    gcTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 
@@ -73,7 +71,6 @@ export default function MainPage() {
     queryKey: ['navQuestion'],
     queryFn: getNavQuestionData,
     staleTime: 30 * 1000,
-    gcTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 

--- a/FE/src/pages/ProfilePage/ProfilePage.tsx
+++ b/FE/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,26 +1,28 @@
+import { Suspense } from 'react';
 import { ProfilePageMetas } from '../../metas/metas';
 import { getUserProfileAPI } from '../../api/profile';
 import {
+  Loading,
   ProfileAnswerList,
   ProfileInfo,
   ProfileQuestionList,
 } from '../../components';
 import { Container, Inner } from './ProfilePage.styles';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
-export default function ProfilePage() {
+const ProfileContent = () => {
   const getUserProfileData = async () => {
     return await getUserProfileAPI();
   };
 
-  const { data: userProfileData } = useQuery({
+  const { data: userProfileData } = useSuspenseQuery({
     queryKey: ['userProfile'],
     queryFn: getUserProfileData,
-    placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
   });
 
   return (
-    <Container>
+    <>
       {userProfileData && (
         <>
           <ProfilePageMetas userName={userProfileData.nickname} />
@@ -41,6 +43,15 @@ export default function ProfilePage() {
           </Inner>
         </>
       )}
+    </>
+  );
+};
+export default function ProfilePage() {
+  return (
+    <Container>
+      <Suspense fallback={<Loading />}>
+        <ProfileContent />
+      </Suspense>
     </Container>
   );
 }

--- a/FE/src/pages/ProfilePage/ProfilePage.tsx
+++ b/FE/src/pages/ProfilePage/ProfilePage.tsx
@@ -16,8 +16,6 @@ export default function ProfilePage() {
   const { data: userProfileData } = useQuery({
     queryKey: ['userProfile'],
     queryFn: getUserProfileData,
-    staleTime: 10 * 1000,
-    gcTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 

--- a/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
+++ b/FE/src/pages/QuestionCreationPage/QuestionCreationPage.tsx
@@ -98,6 +98,7 @@ const QuestionCreationPage = () => {
   const { data: draftData } = useQuery<DraftData>({
     queryKey: ['draft'],
     queryFn: getDraftData,
+    staleTime: 0,
     gcTime: 0,
   });
 

--- a/FE/src/pages/QuestionDetailPage/QuestionDetailPage.styles.ts
+++ b/FE/src/pages/QuestionDetailPage/QuestionDetailPage.styles.ts
@@ -15,6 +15,18 @@ export const Container = styled.div`
   }
 `;
 
+export const AnswerContainer = styled.div`
+  background-color: transparent;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 2rem;
+  width: 100%;
+
+  > * {
+    background-color: ${({ theme }) => theme.color.grayscale.white};
+  }
+`;
+
 export const NoAnswer = styled.div`
   text-align: center;
   padding: 3rem;

--- a/FE/src/pages/QuestionDetailPage/QuestionDetailPage.tsx
+++ b/FE/src/pages/QuestionDetailPage/QuestionDetailPage.tsx
@@ -29,6 +29,7 @@ const QuestionContent = ({ questionId }: { questionId: string }) => {
     queryKey: ['questionDetailContent', questionId],
     queryFn: getContent,
     staleTime: 10 * 6000,
+    gcTime: 30 * 1000,
     refetchOnWindowFocus: false,
     retry: false,
   });
@@ -44,6 +45,8 @@ const QuestionAnswers = ({ questionId }: { questionId: string }) => {
   const { data: questionAnswerListData } = useSuspenseQuery({
     queryKey: ['questionDetailAnswer', questionId],
     queryFn: getAnswers,
+    staleTime: 30 * 1000,
+    gcTime: 30 * 1000,
     refetchOnWindowFocus: false,
     retry: false,
   });

--- a/FE/src/pages/QuestionDetailPage/QuestionDetailPage.tsx
+++ b/FE/src/pages/QuestionDetailPage/QuestionDetailPage.tsx
@@ -33,7 +33,6 @@ const QuestionContent = ({ questionId }: { questionId: string }) => {
     queryKey: ['questionDetailContent', questionId],
     queryFn: getContent,
     staleTime: 10 * 6000,
-    gcTime: 30 * 1000,
     refetchOnWindowFocus: false,
     retry: false,
   });
@@ -56,7 +55,6 @@ const QuestionAnswers = ({
     queryKey: ['questionDetailAnswer', questionId, answerReloadTrigger],
     queryFn: getAnswers,
     staleTime: 30 * 1000,
-    gcTime: 30 * 1000,
     refetchOnWindowFocus: false,
     retry: false,
     placeholderData: keepPreviousData,

--- a/FE/src/pages/QuestionSearchPage/QuestionSearchPage.tsx
+++ b/FE/src/pages/QuestionSearchPage/QuestionSearchPage.tsx
@@ -21,8 +21,6 @@ const QuestionSearchPage = () => {
   const { data: questionListData } = useQuery({
     queryKey: ['questionList', searchQuery, page],
     queryFn: getQuestionListData,
-    staleTime: 10 * 1000,
-    gcTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 

--- a/FE/src/pages/RankingPage/RankingPage.tsx
+++ b/FE/src/pages/RankingPage/RankingPage.tsx
@@ -15,8 +15,6 @@ const RankingPage = () => {
   const { data: rankingListData } = useQuery({
     queryKey: ['rankingList'],
     queryFn: getRankingListData,
-    staleTime: 10 * 1000,
-    gcTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 
@@ -28,8 +26,6 @@ const RankingPage = () => {
   const { data: myRankingData } = useQuery({
     queryKey: ['myRankingData'],
     queryFn: getMyRankingData,
-    staleTime: 10 * 1000,
-    gcTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -32,7 +32,14 @@ const authorizedLoader = () => {
   return isLogined ? redirect('/') : null;
 };
 
-const queryClient = new QueryClient({});
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 10 * 1000,
+      gcTime: 30 * 1000,
+    },
+  },
+});
 
 export const router = createBrowserRouter([
   {

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter, redirect, Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import { MainHeader, MainNav, Loading } from '../components';
+import { MainHeader, MainNav } from '../components';
 import { AuthContextProvider } from '../contexts/AuthContexts';
 import { theme } from '../styles/theme';
 import {
@@ -19,7 +19,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HelmetProvider } from 'react-helmet-async';
 import { DefaultMetas } from '../metas/metas';
-import { Suspense } from 'react';
 
 const { DEV } = import.meta.env;
 
@@ -65,11 +64,7 @@ export const router = createBrowserRouter([
       },
       {
         path: '/question/:id',
-        element: (
-          <Suspense fallback={<Loading />}>
-            <QuestionDetailPage />
-          </Suspense>
-        ),
+        element: <QuestionDetailPage />,
         errorElement: <NotFoundPage />,
       },
       {

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -59,6 +59,7 @@ export const router = createBrowserRouter([
         </AuthContextProvider>
       </QueryClientProvider>
     ),
+    errorElement: <div>Unknown Error</div>,
     children: [
       {
         path: '',

--- a/FE/src/router/index.tsx
+++ b/FE/src/router/index.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter, redirect, Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import { MainHeader, MainNav } from '../components';
+import { MainHeader, MainNav, Loading } from '../components';
 import { AuthContextProvider } from '../contexts/AuthContexts';
 import { theme } from '../styles/theme';
 import {
@@ -19,6 +19,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HelmetProvider } from 'react-helmet-async';
 import { DefaultMetas } from '../metas/metas';
+import { Suspense } from 'react';
 
 const { DEV } = import.meta.env;
 
@@ -64,7 +65,12 @@ export const router = createBrowserRouter([
       },
       {
         path: '/question/:id',
-        element: <QuestionDetailPage />,
+        element: (
+          <Suspense fallback={<Loading />}>
+            <QuestionDetailPage />
+          </Suspense>
+        ),
+        errorElement: <NotFoundPage />,
       },
       {
         path: '/search',

--- a/FE/src/types/type.d.ts
+++ b/FE/src/types/type.d.ts
@@ -48,19 +48,21 @@ export interface SquareButtonProps {
   handleClick?: () => void;
 }
 
-export interface QuestionAnswerCardProps {
-  cardData: {
+export interface QuestionAnswerData {
+  Id: number;
+  User: {
     Id: number;
-    User: {
-      Id: number;
-      Nickname: string;
-      ProfileImage: string;
-    };
-    Content: string;
-    VideoLink: string;
-    IsAdopted: boolean;
-    CreatedAt: string;
+    Nickname: string;
+    ProfileImage: string;
   };
+  Content: string;
+  VideoLink: string;
+  IsAdopted: boolean;
+  CreatedAt: string;
+}
+
+export interface QuestionAnswerCardProps {
+  cardData: QuestionAnswerData;
 }
 
 export interface QuestionAnswerFormCardProps {


### PR DESCRIPTION
## 관련 이슈

Close #295 

## 구현 사항

### 기존의 로딩 상태 관리 로직을 suspense로 대체

질문 상세 페이지에서 isLoading이라는 state로 관리하던 로딩 상태를 suspense로 변경해주었습니다.
이제 로딩 상태를 명령형이 아닌 선언형으로 관리 가능합니다.

### 없는 질문 상세 페이지 접근 제한

없는 질문 상세 페이지로 접근시 404 페이지로 강제 라우팅 되도록 했습니다.

### 랭킹 페이지 및 프로필 페이지 로딩 기능 추가

첫 페이지 로딩시 로딩 UI가 보이는 기능을 추가했습니다.
이제 첫 페이지 진입시 귀여운 펭귄이 왔다갔다 하며 사용자를 덜 지루하게 만들어 줍니다.

### 500 에러 핸들링

에러 핸들링 로직을 추가했습니다.
이제 fetch 도중 500에러가 내려오면 error 메세지가 보입니다.

<br/>

## 추가 논의 사항

한 페이지에서 Suspense를 동시에 사용할 때 fetch Waterfall 현상이 일어나게 하지 않도록 하기 위해 고민 좀 했습니다.
Suspense를 떡칠한다고 좋을 건 없더군요.