### PR TITLE
fix: 프로필 페이지 나의 질문 수정

### DIFF
--- a/FE/src/components/ProfileQuestionList/ProfileQuestionList.tsx
+++ b/FE/src/components/ProfileQuestionList/ProfileQuestionList.tsx
@@ -27,12 +27,12 @@ export function ProfileQuestionList({ userQuestionList }: QuestionListProps) {
         {userQuestionList &&
           userQuestionList.map((data: any) => (
             <ContentDiv key={data.Id}>
-              <p>{data.Title}</p>
-              <p>{data.Tag}</p>
-              <p>{data.ProgrammingLanguage}</p>
-              <p>{data.IsAdopted ? 'O' : 'X'}</p>
-              <p>{data.LikeCount}</p>
-              <p>{getFormalizedDate(data.CreatedAt)}</p>
+              <p>{data.title}</p>
+              <p>{data.tag}</p>
+              <p>{data.programmingLanguage}</p>
+              <p>{data.isAdopted ? 'O' : 'X'}</p>
+              <p>{data.likeCount}</p>
+              <p>{getFormalizedDate(data.createdAt)}</p>
             </ContentDiv>
           ))}
       </QuestionListDiv>

--- a/FE/src/types/type.d.ts
+++ b/FE/src/types/type.d.ts
@@ -108,14 +108,14 @@ export interface GetQuestionListOptions {
 }
 
 export interface QuestionList {
-  Id: number;
-  Title: string;
-  CreatedAt: string;
-  Tag: string;
-  ProgrammingLanguage: string;
-  IsAdopted: boolean;
-  ViewCount: number;
-  LikeCount: number;
+  id: number;
+  title: string;
+  createdAt: string;
+  tag: string;
+  programmingLanguage: string;
+  isAdopted: boolean;
+  viewCount: number;
+  likeCount: number;
 }
 
 export interface AnswerList {


### PR DESCRIPTION
close #309 

- api에서 내려주는 data key값 불일치 수정
### before
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/4df7bdf7-3225-416c-b0f4-1bc131453063)

### after
![image](https://github.com/boostcampwm2023/web04-ALGOCEAN/assets/87417773/175a50e5-4380-40e1-9c97-e4c063e3eff1)
